### PR TITLE
fix: pop opencode kwargs before passing to parent class

### DIFF
--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -40,12 +40,15 @@ class OpenCodeEngineer(BaseEngineer):
     }
 
     def __init__(self, *args, **kwargs):
+        # Pop OpenCode-specific kwargs before passing to parent class
+        self.opencode_provider = kwargs.pop("opencode_provider", "anthropic")
+        self.opencode_model = kwargs.pop("opencode_model", "claude-sonnet-4-5")
+        
         super().__init__(*args, **kwargs)
+        
         # Override UI with OpenCode-specific version
         self.opencode_ui = OpenCodeUI(verbose=kwargs.get("verbose", True))
         self.ui = self.opencode_ui  # Ensure base class uses our specialized UI
-        self.opencode_provider = kwargs.get("opencode_provider", "anthropic")
-        self.opencode_model = kwargs.get("opencode_model", "claude-sonnet-4-5")
         self._last_error: Optional[str] = None
         self._session_id: Optional[str] = None
         self._last_event_time = 0.0


### PR DESCRIPTION
OpenCodeEngineer.__init__() was passing opencode_provider and opencode_model to BaseEngineer.__init__(), which doesn't accept them. This caused a TypeError when using the opencode SDK. Fixed by using pop() to extract these kwargs before calling super().

Moved extraction of 'opencode_provider' and 'opencode_model' from kwargs to before the parent class initialization, using pop to avoid passing them to BaseEngineer. This ensures only relevant arguments are sent to the parent and clarifies initialization logic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Refactored `OpenCodeEngineer` constructor to use `kwargs.pop()` for extracting OpenCode-specific parameters before parent class initialization
- Changed parameter extraction for `opencode_provider` and `opencode_model` to prevent them from being passed to `BaseEngineer`

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/reverse_api/opencode_engineer.py | Refactored constructor to extract OpenCode-specific kwargs before parent initialization to prevent argument leakage |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it's a straightforward parameter handling improvement
- Score reflects a defensive programming fix that prevents potential argument passing issues between parent and child classes
- No files require special attention as the change is isolated and follows good OOP practices

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->