### PR TITLE
feat: add @docs tag for OpenAPI spec generation from HAR files

### DIFF
--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -373,8 +373,8 @@ def repl_loop():
                 # Handle empty input
                 if not raw_input:
                     console.print(" [dim]Usage:[/dim] @id <run_id> [instructions]")
-                    console.print(" [dim]       [/dim] @docs <prompt> (latest run)")
-                    console.print(" [dim]       [/dim] @id <run_id> @docs")
+                    console.print(" [dim]       [/dim] @docs (generate docs for latest run)")
+                    console.print(" [dim]       [/dim] @id <run_id> @docs [prompt]")
                     console.print(" [dim]       [/dim] <run_id> (to switch context)")
                     continue
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -399,6 +399,20 @@ def repl_loop():
                             continue
                         target_run_id = latest_runs[0]["run_id"]
 
+                        # Validate that the latest run has a HAR file
+                        run_data = session_manager.get_run(target_run_id)
+                        if run_data:
+                            paths = run_data.get("paths", {})
+                            har_dir = Path(paths.get("har_dir", get_har_dir(target_run_id, None)))
+                        else:
+                            har_dir = get_har_dir(target_run_id, None)
+
+                        har_path = har_dir / "recording.har"
+                        if not har_path.exists():
+                            console.print(f" [red]error:[/red] latest run ({target_run_id}) has no HAR file")
+                            console.print(" [dim]tip:[/dim] use @id <run_id> @docs to specify a run with captured traffic")
+                            continue
+
                     if not target_run_id:
                         console.print(" [red]error:[/red] invalid @id syntax")
                         continue

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -287,6 +287,7 @@ def run_reverse_engineering(
     enable_sync: bool = False,
     is_fresh: bool = False,
     output_language: str = "python",
+    output_mode: str = "client",
 ) -> dict[str, Any] | None:
     """Run reverse engineering with the specified SDK.
 
@@ -297,6 +298,7 @@ def run_reverse_engineering(
         enable_sync: Enable real-time file syncing during engineering
         is_fresh: Whether to start fresh (ignore previous scripts)
         output_language: Target language - "python", "javascript", or "typescript"
+        output_mode: Output mode - "client" for API client code, "docs" for OpenAPI specification
     """
     if sdk == "opencode":
         from .opencode_engineer import OpenCodeEngineer
@@ -315,6 +317,7 @@ def run_reverse_engineering(
             sdk=sdk,
             is_fresh=is_fresh,
             output_language=output_language,
+            output_mode=output_mode,
         )
     else:
         engineer = ClaudeEngineer(
@@ -329,6 +332,7 @@ def run_reverse_engineering(
             sdk=sdk,
             is_fresh=is_fresh,
             output_language=output_language,
+            output_mode=output_mode,
         )
 
     # Start sync before analysis

--- a/src/reverse_api/session.py
+++ b/src/reverse_api/session.py
@@ -39,6 +39,7 @@ class SessionManager:
             "model": kwargs.get("model"),
             "mode": kwargs.get("mode", "manual"),  # Track which mode was used
             "sdk": kwargs.get("sdk"),
+            "output_mode": kwargs.get("output_mode", "client"),  # Track output format (client/docs)
             "usage": kwargs.get("usage", {}),
             "paths": kwargs.get("paths", {}),
         }

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -236,17 +236,15 @@ def parse_engineer_prompt(input_text: str) -> dict:
             "is_tag_command": False,
         }
 
-    # Check for standalone @docs first
-    if input_text.strip().startswith("@docs"):
-        docs_match = re.match(r"@docs(?:\s+(.*))?", input_text.strip())
-        if docs_match:
-            return {
-                "run_id": None,  # Will use latest run
-                "fresh": False,
-                "docs": True,
-                "prompt": docs_match.group(1) or "",
-                "is_tag_command": True,
-            }
+    # Check for standalone @docs first (no prompt parameter)
+    if input_text.strip() == "@docs":
+        return {
+            "run_id": None,  # Will use latest run
+            "fresh": False,
+            "docs": True,
+            "prompt": "",
+            "is_tag_command": True,
+        }
 
     # Enhanced regex for @id <run_id> [--fresh] [@docs] <prompt>
     # Group 1: run_id

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -317,7 +317,7 @@ def parse_record_only_tag(prompt: str) -> tuple[str, bool]:
         tuple: (cleaned_prompt, is_record_only)
     """
     if not prompt:
-        return prompt, False
+        return "", False
 
     # Match @record-only anywhere in the prompt (case-insensitive)
     pattern = r"@record-only\s*"

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -305,6 +305,28 @@ def parse_engineer_prompt(input_text: str, session_manager=None) -> dict:
     }
 
 
+def parse_record_only_tag(prompt: str) -> tuple[str, bool]:
+    """Parse @record-only tag from prompt.
+
+    When present, skips reverse engineering and only records HAR.
+
+    Args:
+        prompt: The user prompt that may contain @record-only tag
+
+    Returns:
+        tuple: (cleaned_prompt, is_record_only)
+    """
+    if not prompt:
+        return prompt, False
+
+    # Match @record-only anywhere in the prompt (case-insensitive)
+    pattern = r"@record-only\s*"
+    if re.search(pattern, prompt, re.IGNORECASE):
+        cleaned = re.sub(pattern, "", prompt, flags=re.IGNORECASE).strip()
+        return cleaned, True
+    return prompt, False
+
+
 def generate_run_id() -> str:
     """Generate a unique run ID using a short UUID format."""
     return uuid.uuid4().hex[:12]


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Adds `@docs` tag functionality that generates OpenAPI 3.0 specifications from HAR files instead of API client code. The implementation threads an `output_mode` parameter through the engineer pipeline to control whether code generation produces API clients (`client` mode) or OpenAPI documentation (`docs` mode). Both modes support iterative refinement, session history tracking, and dual output to permanent storage (`~/.reverse-api/runs/docs/`) and local workspace (`./docs/`).
