### PR TITLE
fix: opencode

### DIFF
--- a/chrome-extension/src/shared/capture.ts
+++ b/chrome-extension/src/shared/capture.ts
@@ -3,11 +3,10 @@
  */
 
 export function generateRunId(): string {
-  const now = new Date()
-  const date = now.toISOString().slice(0, 10).replace(/-/g, '')
-  const time = now.toTimeString().slice(0, 8).replace(/:/g, '')
-  const random = Math.random().toString(36).substring(2, 6)
-  return `${date}_${time}_${random}`
+  // Generate short UUID with crx prefix
+  // Format: crx-xxxxxxxx (8 hex characters)
+  const shortUuid = Math.random().toString(16).substring(2, 10)
+  return `crx-${shortUuid}`
 }
 
 interface CaptureSettings {

--- a/chrome-extension/src/shared/capture.ts
+++ b/chrome-extension/src/shared/capture.ts
@@ -5,7 +5,7 @@
 export function generateRunId(): string {
   // Generate short UUID with crx prefix
   // Format: crx-xxxxxxxx (8 hex characters)
-  const shortUuid = Math.random().toString(16).substring(2, 10)
+  const shortUuid = Math.random().toString(16).substring(2, 10).padEnd(8, '0')
   return `crx-${shortUuid}`
 }
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -353,7 +353,7 @@ def repl_loop():
     # Get current SDK and model from config
     sdk = config_manager.get("sdk", "claude")
     if sdk == "opencode":
-        model = config_manager.get("opencode_model", "claude-sonnet-4-5")
+        model = config_manager.get("opencode_model", "claude-opus-4-5")
     else:
         model = config_manager.get("claude_code_model", "claude-sonnet-4-5")
 
@@ -683,10 +683,10 @@ def handle_settings(mode_color=THEME_PRIMARY):
                 console.print(f" [dim]updated[/dim] opencode provider: {new_provider}\n")
 
     elif action == "opencode_model":
-        current = config_manager.get("opencode_model", "claude-sonnet-4-5")
+        current = config_manager.get("opencode_model", "claude-opus-4-5")
         new_model = questionary.text(
             " > opencode model",
-            default=current or "claude-sonnet-4-5",
+            default=current or "claude-opus-4-5",
             instruction="(e.g., 'claude-sonnet-4-5', 'claude-opus-4-5')",
             qmark="",
             style=questionary.Style(
@@ -1451,7 +1451,7 @@ def run_auto_capture(prompt=None, url=None, model=None, output_dir=None):
                 prompt=prompt,
                 output_dir=output_dir,
                 opencode_provider=config_manager.get("opencode_provider", "anthropic"),
-                opencode_model=config_manager.get("opencode_model", "claude-sonnet-4-5"),
+                opencode_model=config_manager.get("opencode_model", "claude-opus-4-5"),
                 enable_sync=config_manager.get("real_time_sync", False),
                 sdk=sdk,
                 output_language=output_language,
@@ -1595,7 +1595,7 @@ def run_engineer(
             output_dir=output_dir,
             sdk=sdk,
             opencode_provider=config_manager.get("opencode_provider", "anthropic"),
-            opencode_model=config_manager.get("opencode_model", "claude-sonnet-4-5"),
+            opencode_model=config_manager.get("opencode_model", "claude-opus-4-5"),
             enable_sync=enable_sync,
             additional_instructions=additional_instructions,
             is_fresh=is_fresh,

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -9,7 +9,7 @@ DEFAULT_CONFIG = {
     "browser_use_model": "bu-llm",  # "bu-llm" or "{provider}/{model_name}" (e.g. "openai/gpt-5-mini")
     "claude_code_model": "claude-sonnet-4-5",
     "collector_model": "claude-sonnet-4-5",  # Model for collector mode
-    "opencode_model": "claude-sonnet-4-5",
+    "opencode_model": "claude-opus-4-5",
     "opencode_provider": "anthropic",
     "output_dir": None,  # None means use ~/.reverse-api/runs
     "output_language": "python",  # "python", "javascript", or "typescript"

--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -42,7 +42,7 @@ class OpenCodeEngineer(BaseEngineer):
     def __init__(self, *args, **kwargs):
         # Pop OpenCode-specific kwargs before passing to parent class
         self.opencode_provider = kwargs.pop("opencode_provider", "anthropic")
-        self.opencode_model = kwargs.pop("opencode_model", "claude-sonnet-4-5")
+        self.opencode_model = kwargs.pop("opencode_model", "claude-opus-4-5")
 
         super().__init__(*args, **kwargs)
 
@@ -53,6 +53,16 @@ class OpenCodeEngineer(BaseEngineer):
         self._session_id: str | None = None
         self._last_event_time = 0.0
 
+        # Read OpenCode server authentication from environment variables
+        self.opencode_password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+        self.opencode_username = os.environ.get("OPENCODE_SERVER_USERNAME", "opencode")
+
+    def _get_auth(self) -> httpx.BasicAuth | None:
+        """Get HTTP Basic Auth object if password is configured."""
+        if self.opencode_password:
+            return httpx.BasicAuth(self.opencode_username, self.opencode_password)
+        return None
+
     async def analyze_and_generate(self) -> dict[str, Any] | None:
         """Run the reverse engineering analysis with OpenCode."""
         self.opencode_ui.header(self.run_id, self.prompt, self.opencode_model, self.sdk)
@@ -62,16 +72,27 @@ class OpenCodeEngineer(BaseEngineer):
         self.message_store.save_prompt(self._build_analysis_prompt())
 
         try:
-            async with httpx.AsyncClient(base_url=self.BASE_URL, timeout=600.0) as client:
+            auth = self._get_auth()
+            async with httpx.AsyncClient(base_url=self.BASE_URL, timeout=600.0, auth=auth) as client:
                 # Health check
                 try:
                     health_r = await client.get("/global/health")
                     health_r.raise_for_status()
                     health = health_r.json()
                     self.opencode_ui.health_check(health)
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 401:
+                        debug_log(f"Health check failed: Authentication required")
+                        self.opencode_ui.error("Authentication failed. OpenCode server requires a password.")
+                        self.opencode_ui.console.print("\n[dim]Please set OPENCODE_SERVER_PASSWORD environment variable[/dim]")
+                        if self.opencode_username != "opencode":
+                            self.opencode_ui.console.print(f"[dim]Username: {self.opencode_username}[/dim]")
+                        return None
+                    raise
                 except Exception as e:
                     debug_log(f"Health check failed: {e}")
                     self.opencode_ui.error(f"OpenCode server not responding. Is it running on {self.BASE_URL}?")
+                    self.opencode_ui.console.print("\n[dim]Please run: opencode serve[/dim]")
                     return None
 
                 # Create a new session
@@ -125,7 +146,8 @@ class OpenCodeEngineer(BaseEngineer):
 
             # Fetch actual provider and model used from session messages
             try:
-                async with httpx.AsyncClient(base_url=self.BASE_URL, timeout=10.0) as client:
+                auth = self._get_auth()
+                async with httpx.AsyncClient(base_url=self.BASE_URL, timeout=10.0, auth=auth) as client:
                     messages_r = await client.get(f"/session/{self._session_id}/message")
                     if messages_r.status_code == 200:
                         messages = messages_r.json()
@@ -154,9 +176,22 @@ class OpenCodeEngineer(BaseEngineer):
             self.message_store.save_result(result_data)
             return result_data
 
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                self.opencode_ui.error("Authentication failed. OpenCode server requires a password.")
+                self.opencode_ui.console.print("\n[dim]Please set OPENCODE_SERVER_PASSWORD environment variable[/dim]")
+                if self.opencode_username != "opencode":
+                    self.opencode_ui.console.print(f"[dim]Username: {self.opencode_username}[/dim]")
+                self.message_store.save_error("Authentication failed")
+                return None
+            error_msg = f"HTTP {e.response.status_code}: {str(e)}"
+            self.opencode_ui.error(error_msg)
+            self.message_store.save_error(error_msg)
+            return None
+
         except httpx.ConnectError:
             self.opencode_ui.error("Connection error")
-            self.opencode_ui.console.print("\n[dim]Make sure OpenCode is running: opencode[/dim]")
+            self.opencode_ui.console.print("\n[dim]Please run: opencode serve[/dim]")
             self.message_store.save_error("Connection error")
             return None
 

--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -61,7 +61,8 @@ class OpenCodeEngineer(BaseEngineer):
         """Get HTTP Basic Auth object if password is configured."""
         if self.opencode_password:
             return httpx.BasicAuth(self.opencode_username, self.opencode_password)
-        return None
+                        self.message_store.save_error("Authentication failed")
+                        return None
 
     async def analyze_and_generate(self) -> dict[str, Any] | None:
         """Run the reverse engineering analysis with OpenCode."""

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -112,7 +112,7 @@ async def _generate_folder_name_opencode_async(prompt: str, session_id: str = No
     # Get config for provider and model
     config_manager = ConfigManager(get_config_path())
     opencode_provider = config_manager.get("opencode_provider", "anthropic")
-    opencode_model = config_manager.get("opencode_model", "claude-sonnet-4-5")
+    opencode_model = config_manager.get("opencode_model", "claude-opus-4-5")
 
     folder_prompt = (
         f"Generate a short folder name (1-3 words, lowercase, underscores) for this task: {prompt}\n\n"
@@ -406,9 +406,12 @@ def get_har_dir(run_id: str, output_dir: str | None = None) -> Path:
     if not run_id:
         raise ValueError("run_id cannot be empty")
 
-    # Only allow alphanumeric characters, hyphens, and underscores
+    # Allow alphanumeric characters, hyphens, and underscores
+    # Chrome extension IDs start with crx- followed by UUID-style format
     if not re.match(r"^[a-zA-Z0-9_-]+$", run_id):
-        raise ValueError(f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed")
+        raise ValueError(
+            f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed"
+        )
 
     # Limit length to prevent extremely long paths
     if len(run_id) > 64:
@@ -453,9 +456,12 @@ def get_scripts_dir(run_id: str, output_dir: str | None = None) -> Path:
     if not run_id:
         raise ValueError("run_id cannot be empty")
 
-    # Only allow alphanumeric characters, hyphens, and underscores
+    # Allow alphanumeric characters, hyphens, and underscores
+    # Chrome extension IDs start with crx- followed by UUID-style format
     if not re.match(r"^[a-zA-Z0-9_-]+$", run_id):
-        raise ValueError(f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed")
+        raise ValueError(
+            f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed"
+        )
 
     # Limit length to prevent extremely long paths
     if len(run_id) > 64:
@@ -494,9 +500,12 @@ def get_docs_dir(run_id: str, output_dir: str | None = None) -> Path:
     if not run_id:
         raise ValueError("run_id cannot be empty")
 
-    # Only allow alphanumeric characters, hyphens, and underscores
+    # Allow alphanumeric characters, hyphens, and underscores
+    # Chrome extension IDs start with crx- followed by UUID-style format
     if not re.match(r"^[a-zA-Z0-9_-]+$", run_id):
-        raise ValueError(f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed")
+        raise ValueError(
+            f"Invalid run_id: {run_id}. Only alphanumeric characters, hyphens, and underscores are allowed"
+        )
 
     # Limit length to prevent extremely long paths
     if len(run_id) > 64:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTP Basic Auth support for the OpenCode server with clear 401 handling and setup hints. Switches the default OpenCode model to claude-opus-4-5 and updates the Chrome extension run ID to a short crx-xxxxxxxx format.

- **New Features**
  - Server auth via OPENCODE_SERVER_PASSWORD (optional OPENCODE_SERVER_USERNAME), applied to health checks, sessions, and cleanup, with clearer errors when the server is down or requires auth.

- **Migration**
  - If your server requires auth, set OPENCODE_SERVER_PASSWORD and (optionally) OPENCODE_SERVER_USERNAME.

<sup>Written for commit 347a38e9fd12de9141b3b8acb1e0fe670475a370. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Ajout de l'authentification HTTP Basic pour le serveur OpenCode et changement du modèle par défaut de `claude-sonnet-4-5` à `claude-opus-4-5`. Également, simplification de la génération des IDs pour l'extension Chrome.

Changements principaux:
- Ajout de la prise en charge de l'authentification via les variables d'environnement `OPENCODE_SERVER_PASSWORD` et `OPENCODE_SERVER_USERNAME`
- Gestion améliorée des erreurs 401 avec messages d'aide clairs
- Mise à jour du modèle par défaut OpenCode vers Opus 4.5
- Simplification de l'ID de run de l'extension Chrome (format `crx-xxxxxxxx`)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e07b4d33-1c4e-453f-bed1-db59da843368))

<!-- /greptile_comment -->