### PR TITLE
Update Claude models from 4.5 to 4.6 (Opus and Sonnet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,9 @@ uv run mypy src           # Static analysis
 
 ```json
 {
-  "claude_code_model": "claude-sonnet-4-5",    // For Claude SDK
+  "claude_code_model": "claude-sonnet-4-6",    // For Claude SDK
   "opencode_provider": "anthropic",            // For OpenCode SDK
-  "opencode_model": "claude-sonnet-4-5",       // For OpenCode SDK
+  "opencode_model": "claude-sonnet-4-6",       // For OpenCode SDK
   "sdk": "claude",                             // "claude" or "opencode"
   "agent_provider": "browser-use",             // "browser-use" or "stagehand"
   "browser_use_model": "bu-llm",               // Browser-use agent model
@@ -124,7 +124,7 @@ uv run mypy src           # Static analysis
 ```
 
 ### Model Naming
-- **Claude models**: `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-haiku-4-5`
+- **Claude models**: `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`
 - **Gemini models**: `gemini-3-flash`, `gemini-3-pro`, `gemini-3-pro-low`, `gemini-3-pro-high`
 - **Antigravity models** (free tier): Require OpenCode SDK with `opencode_provider: "google"`
 - **Agent models**: Format varies by provider
@@ -136,7 +136,7 @@ uv run mypy src           # Static analysis
 ### Three-tier fallback for cost calculation:
 1. **Local pricing** (`pricing.py`): Built-in prices for Claude/Gemini models
 2. **LiteLLM pricing** (optional `[pricing]` extra): Extended coverage for 100+ models
-3. **Default pricing**: Falls back to Claude Sonnet 4.5 pricing
+3. **Default pricing**: Falls back to Claude Sonnet 4.6 pricing
 
 Pricing tracks:
 - Input/output tokens

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ No more manual reverse engineering—just browse, capture, and get clean API cod
 - 🌐 **Browser Automation**: Built on Playwright with stealth mode for realistic browsing
 - 🤖 **Autonomous Agent Mode**: Fully automated browser interaction using AI agents (auto mode with MCP, browser-use, stagehand)
 - 📊 **HAR Recording**: Captures all network traffic in HTTP Archive format
-- 🧠 **AI-Powered Generation**: Uses Claude 4.5 to analyze traffic and generate clean Python code
+- 🧠 **AI-Powered Generation**: Uses Claude 4.6 to analyze traffic and generate clean Python code
 - 🔍 **Collector Mode**: Data collection with automatic JSON/CSV export
 - 🔌 **Multi-SDK Support**: Native integration with Claude and OpenCode SDKs
 - 💻 **Interactive CLI**: Minimalist terminal interface with mode cycling (Shift+Tab)
@@ -85,7 +85,7 @@ playwright install chromium
 
 ### Enhanced Pricing Support (Optional)
 
-By default, Reverse API Engineer includes pricing data for the most common models (Claude 4.5, Gemini 3). For extended model coverage (100+ additional models including OpenAI GPT, Mistral, DeepSeek, and more), install with pricing extras:
+By default, Reverse API Engineer includes pricing data for the most common models (Claude 4.6, Gemini 3). For extended model coverage (100+ additional models including OpenAI GPT, Mistral, DeepSeek, and more), install with pricing extras:
 
 ```bash
 # With uv
@@ -98,7 +98,7 @@ pip install 'reverse-api-engineer[pricing]'
 This enables automatic pricing lookup via [LiteLLM](https://github.com/BerriAI/litellm) for models not in the built-in database. The pricing system uses a 3-tier fallback:
 1. **Local pricing** (highest priority) - Built-in pricing for common models
 2. **LiteLLM pricing** (if installed) - Extended coverage for 100+ models
-3. **Default pricing** (ultimate fallback) - Uses Claude Sonnet 4.5 pricing
+3. **Default pricing** (ultimate fallback) - Uses Claude Sonnet 4.6 pricing
 
 Cost tracking will always work, with or without the pricing extras installed.
 
@@ -191,7 +191,7 @@ Web data collection using Claude Agent SDK:
 - `README.md` - Collection metadata and schema documentation
 
 **Model Configuration:**
-Collector mode uses the `collector_model` setting (default: `claude-sonnet-4-5`). This can be configured in `~/.reverse-api/config.json`.
+Collector mode uses the `collector_model` setting (default: `claude-sonnet-4-6`). This can be configured in `~/.reverse-api/config.json`.
 
 Example workflow:
 ```bash
@@ -245,9 +245,9 @@ Settings stored in `~/.reverse-api/config.json`:
 {
   "agent_provider": "auto",
   "browser_use_model": "bu-llm",
-  "claude_code_model": "claude-sonnet-4-5",
-  "collector_model": "claude-sonnet-4-5",
-  "opencode_model": "claude-sonnet-4-5",
+  "claude_code_model": "claude-sonnet-4-6",
+  "collector_model": "claude-sonnet-4-6",
+  "opencode_model": "claude-sonnet-4-6",
   "opencode_provider": "anthropic",
   "output_dir": null,
   "output_language": "python",
@@ -259,14 +259,14 @@ Settings stored in `~/.reverse-api/config.json`:
 
 ### Model Selection
 
-Choose from Claude 4.5 models for API generation:
-- **Sonnet 4.5** (default): Balanced performance and cost
-- **Opus 4.5**: Maximum capability for complex APIs
+Choose from Claude 4.6 models for API generation:
+- **Sonnet 4.6** (default): Balanced performance and cost
+- **Opus 4.6**: Maximum capability for complex APIs
 - **Haiku 4.5**: Fastest and most economical
 
 Change in `/settings` or via CLI:
 ```bash
-reverse-api-engineer manual --model claude-sonnet-4-5
+reverse-api-engineer manual --model claude-sonnet-4-6
 ```
 
 If you use Opencode, look at the [models](https://models.dev).
@@ -289,9 +289,9 @@ Configure AI agents for autonomous browser automation.
 
 **Stagehand Provider (Computer Use only):**
 - `openai/computer-use-preview-2025-03-11` - Requires `OPENAI_API_KEY`
-- `anthropic/claude-sonnet-4-5-20250929` - Requires `ANTHROPIC_API_KEY`
+- `anthropic/claude-sonnet-4-6-20260301` - Requires `ANTHROPIC_API_KEY`
 - `anthropic/claude-haiku-4-5-20251001` - Requires `ANTHROPIC_API_KEY`
-- `anthropic/claude-opus-4-5-20251101` - Requires `ANTHROPIC_API_KEY`
+- `anthropic/claude-opus-4-6-20260301` - Requires `ANTHROPIC_API_KEY`
 
 **Setting API Keys:**
 ```bash

--- a/chrome-extension/src/shared/storage.ts
+++ b/chrome-extension/src/shared/storage.ts
@@ -6,7 +6,7 @@ import type { Settings } from './types'
 
 const DEFAULT_SETTINGS: Settings = {
   captureTypes: ['xhr', 'fetch', 'websocket'],
-  lastModel: 'claude-sonnet-4-5'
+  lastModel: 'claude-sonnet-4-6'
 }
 
 export async function getSettings(): Promise<Settings> {

--- a/chrome-extension/src/sidepanel/side-panel.tsx
+++ b/chrome-extension/src/sidepanel/side-panel.tsx
@@ -22,7 +22,7 @@ const DEFAULT_STATE: AppState = {
 }
 
 const DEFAULT_SETTINGS: Settings = {
-  lastModel: 'claude-sonnet-4-5',
+  lastModel: 'claude-sonnet-4-6',
   captureTypes: ['xhr', 'fetch', 'websocket'],
 }
 

--- a/src/reverse_api/browser.py
+++ b/src/reverse_api/browser.py
@@ -707,9 +707,9 @@ def parse_agent_model(agent_model: str, agent_provider: str = "browser-use") -> 
                 ]
 
                 anthropic_cua_models = [
-                    "claude-sonnet-4-5-20250929",
+                    "claude-sonnet-4-6-20260301",
                     "claude-haiku-4-5-20251001",
-                    "claude-opus-4-5-20251101",
+                    "claude-opus-4-6-20260301",
                 ]
 
                 if provider == "openai":

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -261,7 +261,7 @@ def prompt_interactive_options(
         return {
             "mode": result_mode,
             "run_id": prompt,
-            "model": model or config_manager.get("claude_code_model", "claude-sonnet-4-5"),
+            "model": model or config_manager.get("claude_code_model", "claude-sonnet-4-6"),
         }
 
     # Agent mode: similar to manual but uses autonomous browser
@@ -285,7 +285,7 @@ def prompt_interactive_options(
                 raise click.Abort()
 
         if model is None:
-            model = config_manager.get("claude_code_model", "claude-sonnet-4-5")
+            model = config_manager.get("claude_code_model", "claude-sonnet-4-6")
 
         return {
             "mode": result_mode,
@@ -298,7 +298,7 @@ def prompt_interactive_options(
     # Collector mode: just needs prompt
     if result_mode == "collector":
         if model is None:
-            model = config_manager.get("collector_model", "claude-sonnet-4-5")
+            model = config_manager.get("collector_model", "claude-sonnet-4-6")
 
         return {
             "mode": result_mode,
@@ -330,7 +330,7 @@ def prompt_interactive_options(
         reverse_engineer = True
 
     if model is None:
-        model = config_manager.get("claude_code_model", "claude-sonnet-4-5")
+        model = config_manager.get("claude_code_model", "claude-sonnet-4-6")
 
     return {
         "mode": result_mode,
@@ -356,9 +356,9 @@ def repl_loop():
     # Get current SDK and model from config
     sdk = config_manager.get("sdk", "claude")
     if sdk == "opencode":
-        model = config_manager.get("opencode_model", "claude-opus-4-5")
+        model = config_manager.get("opencode_model", "claude-opus-4-6")
     else:
-        model = config_manager.get("claude_code_model", "claude-sonnet-4-5")
+        model = config_manager.get("claude_code_model", "claude-sonnet-4-6")
 
     display_banner(console, sdk=sdk, model=model)
     console.print("  [dim]shift+tab to cycle modes: manual | engineer | agent | collector[/dim]")
@@ -691,11 +691,11 @@ def handle_settings(mode_color=THEME_PRIMARY):
                 console.print(f" [dim]updated[/dim] opencode provider: {new_provider}\n")
 
     elif action == "opencode_model":
-        current = config_manager.get("opencode_model", "claude-opus-4-5")
+        current = config_manager.get("opencode_model", "claude-opus-4-6")
         new_model = questionary.text(
             " > opencode model",
-            default=current or "claude-opus-4-5",
-            instruction="(e.g., 'claude-sonnet-4-5', 'claude-opus-4-5')",
+            default=current or "claude-opus-4-6",
+            instruction="(e.g., 'claude-sonnet-4-6', 'claude-opus-4-6')",
             qmark="",
             style=questionary.Style(
                 [
@@ -754,7 +754,7 @@ def handle_settings(mode_color=THEME_PRIMARY):
 
         current = config_manager.get("stagehand_model", "openai/computer-use-preview-2025-03-11")
         instruction = (
-            "(Format: 'openai/model' or 'anthropic/model', e.g., 'openai/computer-use-preview-2025-03-11' or 'anthropic/claude-sonnet-4-5-20250929')"
+            "(Format: 'openai/model' or 'anthropic/model', e.g., 'openai/computer-use-preview-2025-03-11' or 'anthropic/claude-sonnet-4-6-20250929')"
         )
 
         new_model = questionary.text(
@@ -784,9 +784,9 @@ def handle_settings(mode_color=THEME_PRIMARY):
                     console.print(
                         " [dim]Valid formats for stagehand:[/dim]\n"
                         " [dim]  - openai/computer-use-preview-2025-03-11[/dim]\n"
-                        " [dim]  - anthropic/claude-sonnet-4-5-20250929[/dim]\n"
+                        " [dim]  - anthropic/claude-sonnet-4-6-20250929[/dim]\n"
                         " [dim]  - anthropic/claude-haiku-4-5-20251001[/dim]\n"
-                        " [dim]  - anthropic/claude-opus-4-5-20251101[/dim]\n"
+                        " [dim]  - anthropic/claude-opus-4-6-20251101[/dim]\n"
                     )
 
     elif action == "real_time_sync":
@@ -895,7 +895,7 @@ def handle_history(mode_color=THEME_PRIMARY):
         console.print()
 
         if questionary.confirm(" > recode?", qmark="").ask():
-            model = run.get("model") or config_manager.get("claude_code_model", "claude-sonnet-4-5")
+            model = run.get("model") or config_manager.get("claude_code_model", "claude-sonnet-4-6")
             run_engineer(run_id, model=model)
     else:
         console.print(" [dim]> not found[/dim]")
@@ -1145,7 +1145,7 @@ def handle_messages(run_id: str, mode_color=THEME_PRIMARY):
 @click.option(
     "--model",
     "-m",
-    type=click.Choice(["claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5"]),
+    type=click.Choice(["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5"]),
     default=None,
 )
 @click.option("--output-dir", "-o", default=None, help="Custom output directory.")
@@ -1377,7 +1377,7 @@ def run_collector(prompt=None, model=None, output_dir=None):
 
     # Use collector model from config if not specified
     if model is None:
-        model = config_manager.get("collector_model", "claude-sonnet-4-5")
+        model = config_manager.get("collector_model", "claude-sonnet-4-6")
 
     # Initialize session
     session_manager.add_run(
@@ -1459,7 +1459,7 @@ def run_auto_capture(prompt=None, url=None, model=None, output_dir=None):
                 prompt=prompt,
                 output_dir=output_dir,
                 opencode_provider=config_manager.get("opencode_provider", "anthropic"),
-                opencode_model=config_manager.get("opencode_model", "claude-opus-4-5"),
+                opencode_model=config_manager.get("opencode_model", "claude-opus-4-6"),
                 enable_sync=config_manager.get("real_time_sync", False),
                 sdk=sdk,
                 output_language=output_language,
@@ -1470,7 +1470,7 @@ def run_auto_capture(prompt=None, url=None, model=None, output_dir=None):
             engineer = ClaudeAutoEngineer(
                 run_id=run_id,
                 prompt=prompt,
-                model=model or config_manager.get("claude_code_model", "claude-sonnet-4-5"),
+                model=model or config_manager.get("claude_code_model", "claude-sonnet-4-6"),
                 output_dir=output_dir,
                 enable_sync=config_manager.get("real_time_sync", False),
                 sdk=sdk,
@@ -1550,7 +1550,7 @@ def run_playwright_codegen(run_id: str, prompt: str, output_dir: str | None = No
 @click.option(
     "--model",
     "-m",
-    type=click.Choice(["claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5"]),
+    type=click.Choice(["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5"]),
     default=None,
 )
 @click.option("--output-dir", "-o", default=None, help="Custom output directory.")
@@ -1603,7 +1603,7 @@ def run_engineer(
             output_dir=output_dir,
             sdk=sdk,
             opencode_provider=config_manager.get("opencode_provider", "anthropic"),
-            opencode_model=config_manager.get("opencode_model", "claude-opus-4-5"),
+            opencode_model=config_manager.get("opencode_model", "claude-opus-4-6"),
             enable_sync=enable_sync,
             additional_instructions=additional_instructions,
             is_fresh=is_fresh,
@@ -1615,7 +1615,7 @@ def run_engineer(
             run_id=run_id,
             har_path=har_path,
             prompt=prompt,
-            model=model or config_manager.get("claude_code_model", "claude-sonnet-4-5"),
+            model=model or config_manager.get("claude_code_model", "claude-sonnet-4-6"),
             output_dir=output_dir,
             sdk=sdk,
             enable_sync=enable_sync,

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -784,9 +784,9 @@ def handle_settings(mode_color=THEME_PRIMARY):
                     console.print(
                         " [dim]Valid formats for stagehand:[/dim]\n"
                         " [dim]  - openai/computer-use-preview-2025-03-11[/dim]\n"
-                        " [dim]  - anthropic/claude-sonnet-4-6-20250929[/dim]\n"
+                        " [dim]  - anthropic/claude-sonnet-4-6-20260301[/dim]\n"
                         " [dim]  - anthropic/claude-haiku-4-5-20251001[/dim]\n"
-                        " [dim]  - anthropic/claude-opus-4-6-20251101[/dim]\n"
+                        " [dim]  - anthropic/claude-opus-4-6-20260301[/dim]\n"
                     )
 
     elif action == "real_time_sync":

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -754,7 +754,7 @@ def handle_settings(mode_color=THEME_PRIMARY):
 
         current = config_manager.get("stagehand_model", "openai/computer-use-preview-2025-03-11")
         instruction = (
-            "(Format: 'openai/model' or 'anthropic/model', e.g., 'openai/computer-use-preview-2025-03-11' or 'anthropic/claude-sonnet-4-6-20250929')"
+            "(Format: 'openai/model' or 'anthropic/model', e.g., 'openai/computer-use-preview-2025-03-11' or 'anthropic/claude-sonnet-4-6-20260301')"
         )
 
         new_model = questionary.text(

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -7,9 +7,9 @@ from typing import Any
 DEFAULT_CONFIG = {
     "agent_provider": "auto",  # "auto" (default, MCP-based browser + engineering), "browser-use", or "stagehand"
     "browser_use_model": "bu-llm",  # "bu-llm" or "{provider}/{model_name}" (e.g. "openai/gpt-5-mini")
-    "claude_code_model": "claude-sonnet-4-5",
-    "collector_model": "claude-sonnet-4-5",  # Model for collector mode
-    "opencode_model": "claude-opus-4-5",
+    "claude_code_model": "claude-sonnet-4-6",
+    "collector_model": "claude-sonnet-4-6",  # Model for collector mode
+    "opencode_model": "claude-opus-4-6",
     "opencode_provider": "anthropic",
     "output_dir": None,  # None means use ~/.reverse-api/runs
     "output_language": "python",  # "python", "javascript", or "typescript"

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -294,7 +294,7 @@ def run_reverse_engineering(
     Args:
         sdk: "opencode" or "claude" - determines which SDK to use
         opencode_provider: Provider ID for OpenCode (e.g., "anthropic")
-        opencode_model: Model ID for OpenCode (e.g., "claude-sonnet-4-5")
+        opencode_model: Model ID for OpenCode (e.g., "claude-sonnet-4-6")
         enable_sync: Enable real-time file syncing during engineering
         is_fresh: Whether to start fresh (ignore previous scripts)
         output_language: Target language - "python", "javascript", or "typescript"

--- a/src/reverse_api/native_host.py
+++ b/src/reverse_api/native_host.py
@@ -549,7 +549,7 @@ class NativeHostHandler:
                 "_callbackId": message.get("_callbackId"),
             }
 
-        model = message.get("model") or self.config.get("claude_code_model") or "claude-sonnet-4-5"
+        model = message.get("model") or self.config.get("claude_code_model") or "claude-sonnet-4-6"
         scripts_dir = get_scripts_dir(run_id)
         scripts_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -103,15 +103,15 @@ class OpenCodeEngineer(BaseEngineer):
 
     # Map short model names to full Anthropic model IDs
     MODEL_MAP = {
-        "sonnet": "claude-sonnet-4-5",
-        "opus": "claude-opus-4-5",
+        "sonnet": "claude-sonnet-4-6",
+        "opus": "claude-opus-4-6",
         "haiku": "claude-haiku-4-5",
     }
 
     def __init__(self, *args, **kwargs):
         # Pop OpenCode-specific kwargs before passing to parent class
         self.opencode_provider = kwargs.pop("opencode_provider", "anthropic")
-        self.opencode_model = kwargs.pop("opencode_model", "claude-opus-4-5")
+        self.opencode_model = kwargs.pop("opencode_model", "claude-opus-4-6")
 
         super().__init__(*args, **kwargs)
 

--- a/src/reverse_api/pricing.py
+++ b/src/reverse_api/pricing.py
@@ -1,14 +1,14 @@
 """Pricing models for different models."""
 
 MODEL_PRICING = {
-    "claude-sonnet-4-5": {
+    "claude-sonnet-4-6": {
         "input": 3.00,
         "output": 15.00,
         "cache_creation": 3.75,
         "cache_read": 0.30,
         "reasoning": 15.00,
     },
-    "claude-opus-4-5": {
+    "claude-opus-4-6": {
         "input": 15.00,
         "output": 25.00,
         "cache_creation": 6.25,
@@ -50,42 +50,42 @@ MODEL_PRICING = {
         "cache_read": 0.20,
         "reasoning": 12,
     },
-    "claude-sonnet-4-5-thinking-low": {
+    "claude-sonnet-4-6-thinking-low": {
         "input": 3.00,
         "output": 15.00,
         "cache_creation": 3.75,
         "cache_read": 0.30,
         "reasoning": 15.00,
     },
-    "claude-sonnet-4-5-thinking-medium": {
+    "claude-sonnet-4-6-thinking-medium": {
         "input": 3.00,
         "output": 15.00,
         "cache_creation": 3.75,
         "cache_read": 0.30,
         "reasoning": 15.00,
     },
-    "claude-sonnet-4-5-thinking-high": {
+    "claude-sonnet-4-6-thinking-high": {
         "input": 3.00,
         "output": 15.00,
         "cache_creation": 3.75,
         "cache_read": 0.30,
         "reasoning": 15.00,
     },
-    "claude-opus-4-5-thinking-low": {
+    "claude-opus-4-6-thinking-low": {
         "input": 15.00,
         "output": 25.00,
         "cache_creation": 6.25,
         "cache_read": 0.50,
         "reasoning": 25.00,
     },
-    "claude-opus-4-5-thinking-medium": {
+    "claude-opus-4-6-thinking-medium": {
         "input": 15.00,
         "output": 25.00,
         "cache_creation": 6.25,
         "cache_read": 0.50,
         "reasoning": 25.00,
     },
-    "claude-opus-4-5-thinking-high": {
+    "claude-opus-4-6-thinking-high": {
         "input": 15.00,
         "output": 25.00,
         "cache_creation": 6.25,
@@ -98,14 +98,13 @@ MODEL_PRICING = {
 # Model name mapping for LiteLLM compatibility
 # Maps our model IDs to possible LiteLLM model name variations
 _LITELLM_MODEL_MAP = {
-    "claude-sonnet-4-5": [
-        "claude-sonnet-4-5",
-        "anthropic.claude-sonnet-4-5",
-        "claude-3-5-sonnet-20241022",
+    "claude-sonnet-4-6": [
+        "claude-sonnet-4-6",
+        "anthropic.claude-sonnet-4-6",
     ],
-    "claude-opus-4-5": [
-        "claude-opus-4-5",
-        "anthropic.claude-opus-4-5",
+    "claude-opus-4-6": [
+        "claude-opus-4-6",
+        "anthropic.claude-opus-4-6",
     ],
     "claude-haiku-4-5": [
         "claude-haiku-4-5",
@@ -213,10 +212,10 @@ def calculate_cost(
     Uses a 3-tier fallback system:
     1. Local MODEL_PRICING dictionary (highest priority)
     2. LiteLLM pricing package (if installed and model found)
-    3. Claude Sonnet 4.5 pricing (ultimate fallback)
+    3. Claude Sonnet 4.6 pricing (ultimate fallback)
 
     Args:
-        model_id: Model identifier (e.g., "claude-sonnet-4-5")
+        model_id: Model identifier (e.g., "claude-sonnet-4-6")
         input_tokens: Number of input tokens
         output_tokens: Number of output tokens
         cache_creation_tokens: Number of tokens written to cache
@@ -231,7 +230,7 @@ def calculate_cost(
     elif model_id and (litellm_pricing := _get_pricing_from_litellm(model_id)):
         pricing = litellm_pricing
     else:
-        pricing = MODEL_PRICING["claude-sonnet-4-5"]
+        pricing = MODEL_PRICING["claude-sonnet-4-6"]
 
     cost = (
         (input_tokens / 1_000_000 * pricing["input"])

--- a/src/reverse_api/tui.py
+++ b/src/reverse_api/tui.py
@@ -189,8 +189,8 @@ class ClaudeUI:
 def get_model_choices() -> list[dict]:
     """Get available model choices for questionary."""
     return [
-        {"name": "Sonnet 4.5 [Balanced]", "value": "claude-sonnet-4-5"},
-        {"name": "Opus 4.5 [Power]", "value": "claude-opus-4-5"},
+        {"name": "Sonnet 4.6 [Balanced]", "value": "claude-sonnet-4-6"},
+        {"name": "Opus 4.6 [Power]", "value": "claude-opus-4-6"},
         {"name": "Haiku 4.5 [Speed]", "value": "claude-haiku-4-5"},
     ]
 

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -136,7 +136,7 @@ async def _generate_folder_name_opencode_async(prompt: str, session_id: str = No
     # Get config for provider and model
     config_manager = ConfigManager(get_config_path())
     opencode_provider = config_manager.get("opencode_provider", "anthropic")
-    opencode_model = config_manager.get("opencode_model", "claude-opus-4-5")
+    opencode_model = config_manager.get("opencode_model", "claude-opus-4-6")
 
     folder_prompt = (
         f"Generate a short folder name (1-3 words, lowercase, underscores) for this task: {prompt}\n\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,8 @@ def sample_config():
     """Sample configuration data."""
     return {
         "sdk": "claude",
-        "claude_code_model": "claude-sonnet-4-5",
-        "opencode_model": "claude-opus-4-5",
+        "claude_code_model": "claude-sonnet-4-6",
+        "opencode_model": "claude-opus-4-6",
         "opencode_provider": "anthropic",
         "output_dir": None,
     }

--- a/tests/test_auto_engineer.py
+++ b/tests/test_auto_engineer.py
@@ -21,7 +21,7 @@ class TestClaudeAutoEngineerInit:
                     eng = ClaudeAutoEngineer(
                         run_id="test123",
                         prompt="browse and capture",
-                        model="claude-sonnet-4-5",
+                        model="claude-sonnet-4-6",
                         output_dir=str(tmp_path),
                     )
                     assert eng.mcp_run_id == "test123"
@@ -35,7 +35,7 @@ class TestClaudeAutoEngineerPrompt:
         defaults = {
             "run_id": "test123",
             "prompt": "browse and capture",
-            "model": "claude-sonnet-4-5",
+            "model": "claude-sonnet-4-6",
             "output_dir": str(tmp_path),
         }
         defaults.update(kwargs)
@@ -99,7 +99,7 @@ class TestClaudeAutoEngineerAnalyze:
         defaults = {
             "run_id": "test123",
             "prompt": "browse and capture",
-            "model": "claude-sonnet-4-5",
+            "model": "claude-sonnet-4-6",
             "output_dir": str(tmp_path),
         }
         defaults.update(kwargs)
@@ -452,7 +452,7 @@ class TestOpenCodeAutoEngineerInit:
                             prompt="browse and capture",
                             output_dir=str(tmp_path),
                             opencode_provider="anthropic",
-                            opencode_model="claude-opus-4-5",
+                            opencode_model="claude-opus-4-6",
                         )
                         assert eng.mcp_run_id == "test123"
                         assert eng.mcp_name is None
@@ -468,7 +468,7 @@ class TestOpenCodeAutoEngineerInit:
                             prompt="browse and capture",
                             output_dir=str(tmp_path),
                             opencode_provider="anthropic",
-                            opencode_model="claude-opus-4-5",
+                            opencode_model="claude-opus-4-6",
                         )
                         prompt = eng._build_auto_prompt()
                         assert "browser_navigate" in prompt
@@ -490,7 +490,7 @@ class TestOpenCodeAutoEngineerAnalyze:
                             prompt="browse and capture",
                             output_dir=str(tmp_path),
                             opencode_provider="anthropic",
-                            opencode_model="claude-opus-4-5",
+                            opencode_model="claude-opus-4-6",
                         )
                         eng.scripts_dir = tmp_path / "scripts"
                         eng.scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -658,7 +658,7 @@ class TestOpenCodeAutoEngineerAnalyze:
         mock_messages.status_code = 200
         mock_messages.json.return_value = [
             {
-                "info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-opus-4-5"},
+                "info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-opus-4-6"},
                 "parts": [{"type": "text", "text": "API client"}],
             }
         ]
@@ -844,7 +844,7 @@ class TestOpenCodeAutoEngineerAnalyze:
         mock_messages = MagicMock()
         mock_messages.status_code = 200
         mock_messages.json.return_value = [
-            {"info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-sonnet-4-5"}, "parts": []}
+            {"info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-sonnet-4-6"}, "parts": []}
         ]
 
         async def mock_get(path, **kwargs):

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -30,13 +30,13 @@ class TestBaseEngineerInit:
                     run_id="test123",
                     har_path=har_path,
                     prompt="test prompt",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                     output_dir=str(tmp_path),
                 )
                 assert engineer.run_id == "test123"
                 assert engineer.har_path == har_path
                 assert engineer.prompt == "test prompt"
-                assert engineer.model == "claude-sonnet-4-5"
+                assert engineer.model == "claude-sonnet-4-6"
                 assert engineer.output_mode == "client"
                 assert engineer.is_fresh is False
                 assert engineer.output_language == "python"

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -20,11 +20,11 @@ class TestCollectorInit:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect startup data",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 assert collector.run_id == "test123"
                 assert collector.prompt == "collect startup data"
-                assert collector.model == "claude-sonnet-4-5"
+                assert collector.model == "claude-sonnet-4-6"
                 assert collector.usage_metadata == {}
 
     def test_init_with_output_dir(self):
@@ -34,7 +34,7 @@ class TestCollectorInit:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                     output_dir="/custom/output",
                 )
                 assert collector.output_dir == "/custom/output"
@@ -50,7 +50,7 @@ class TestCollectorBuildPrompt:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect Y Combinator startups",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = Path("/tmp/test")
                 collector.items_path = Path("/tmp/test/items.jsonl")
@@ -74,7 +74,7 @@ class TestCollectorRun:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect startups",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
 
                 collected_dir = tmp_path / "collected"
@@ -103,7 +103,7 @@ class TestCollectorRun:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect stuff",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
 
                 with patch("reverse_api.collector.generate_folder_name", return_value="test"):
@@ -124,7 +124,7 @@ class TestCollectorRun:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect stuff",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
 
                 with patch("reverse_api.collector.generate_folder_name", return_value="test"):
@@ -151,7 +151,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
 
@@ -174,7 +174,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -211,7 +211,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -247,7 +247,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -310,7 +310,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -359,7 +359,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -407,7 +407,7 @@ class TestCollectorAgentLoop:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector.items_path = tmp_path / "items.jsonl"
@@ -440,7 +440,7 @@ class TestCollectorExportCsv:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 items = [
                     {"name": "Acme", "url": "https://acme.com"},
@@ -464,7 +464,7 @@ class TestCollectorExportCsv:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 items = [
                     {"name": "Acme", "category": "tech"},
@@ -486,7 +486,7 @@ class TestCollectorExportCsv:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 csv_path = tmp_path / "data.csv"
                 collector._export_csv(csv_path, [])
@@ -499,7 +499,7 @@ class TestCollectorExportCsv:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 items = [{"name": "Acme", "value": None}]
                 csv_path = tmp_path / "data.csv"
@@ -521,7 +521,7 @@ class TestCollectorExportReadme:
                 collector = Collector(
                     run_id="test123",
                     prompt="collect startups",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._folder_name = "startups"
 
@@ -549,7 +549,7 @@ class TestCollectorExportReadme:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._folder_name = None
 
@@ -570,7 +570,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = None
                 result = collector._finalize_collection()
@@ -583,7 +583,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -598,7 +598,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -616,7 +616,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -646,7 +646,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -670,7 +670,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -697,7 +697,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"
@@ -720,7 +720,7 @@ class TestCollectorFinalizeCollection:
                 collector = Collector(
                     run_id="test123",
                     prompt="test",
-                    model="claude-sonnet-4-5",
+                    model="claude-sonnet-4-6",
                 )
                 collector._collected_dir = tmp_path
                 collector._folder_name = "test"

--- a/tests/test_collector_ui.py
+++ b/tests/test_collector_ui.py
@@ -26,7 +26,7 @@ class TestCollectorUI:
     def test_header(self):
         """Header displays collector info."""
         ui, console = self._make_ui()
-        ui.header("run123", "collect startup data", "claude-sonnet-4-5")
+        ui.header("run123", "collect startup data", "claude-sonnet-4-6")
         output = console.file.getvalue()
         assert "run123" in output
         assert "collect startup data" in output
@@ -35,7 +35,7 @@ class TestCollectorUI:
         """Header truncates prompts longer than 80 chars."""
         ui, console = self._make_ui()
         long_prompt = "x" * 100
-        ui.header("run123", long_prompt, "claude-sonnet-4-5")
+        ui.header("run123", long_prompt, "claude-sonnet-4-6")
         output = console.file.getvalue()
         assert "..." in output
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,10 +19,10 @@ class TestConfigManagerInit:
     def test_loads_existing_config(self, config_path):
         """ConfigManager loads config from existing file."""
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps({"sdk": "opencode", "claude_code_model": "claude-opus-4-5"}))
+        config_path.write_text(json.dumps({"sdk": "opencode", "claude_code_model": "claude-opus-4-6"}))
         cm = ConfigManager(config_path)
         assert cm.get("sdk") == "opencode"
-        assert cm.get("claude_code_model") == "claude-opus-4-5"
+        assert cm.get("claude_code_model") == "claude-opus-4-6"
 
     def test_ignores_invalid_keys(self, config_path):
         """ConfigManager ignores keys not in DEFAULT_CONFIG."""
@@ -52,9 +52,9 @@ class TestConfigMigration:
     def test_migrate_model_to_claude_code_model(self, config_path):
         """Old 'model' key migrates to 'claude_code_model'."""
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps({"model": "claude-opus-4-5"}))
+        config_path.write_text(json.dumps({"model": "claude-opus-4-6"}))
         cm = ConfigManager(config_path)
-        assert cm.get("claude_code_model") == "claude-opus-4-5"
+        assert cm.get("claude_code_model") == "claude-opus-4-6"
 
     def test_no_migrate_if_claude_code_model_exists(self, config_path):
         """Migration skipped if 'claude_code_model' already set."""

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -57,7 +57,7 @@ class TestRunReverseEngineering:
                     prompt="test prompt",
                     sdk="opencode",
                     opencode_provider="anthropic",
-                    opencode_model="claude-opus-4-5",
+                    opencode_model="claude-opus-4-6",
                 )
                 mock_cls.assert_called_once()
 
@@ -116,7 +116,7 @@ class TestRunReverseEngineering:
                     run_id="test123",
                     har_path=har_path,
                     prompt="test",
-                    model="claude-opus-4-5",
+                    model="claude-opus-4-6",
                     additional_instructions="extra",
                     output_dir="/custom",
                     verbose=False,
@@ -127,7 +127,7 @@ class TestRunReverseEngineering:
                 )
                 kwargs = mock_cls.call_args[1]
                 assert kwargs["run_id"] == "test123"
-                assert kwargs["model"] == "claude-opus-4-5"
+                assert kwargs["model"] == "claude-opus-4-6"
                 assert kwargs["output_language"] == "typescript"
                 assert kwargs["output_mode"] == "docs"
                 assert kwargs["is_fresh"] is True

--- a/tests/test_native_host.py
+++ b/tests/test_native_host.py
@@ -594,7 +594,7 @@ class TestNativeHostGenerateAsync:
     def _make_handler(self):
         with patch("reverse_api.native_host.ConfigManager") as mock_cm:
             mock_cm.return_value.config_path = Path("/test/config.json")
-            mock_cm.return_value.get.return_value = "claude-sonnet-4-5"
+            mock_cm.return_value.get.return_value = "claude-sonnet-4-6"
             return NativeHostHandler()
 
     @pytest.mark.asyncio
@@ -603,7 +603,7 @@ class TestNativeHostGenerateAsync:
         handler = self._make_handler()
 
         with patch("reverse_api.native_host.get_har_dir", return_value=tmp_path / "har"):
-            result = await handler._generate_async("run123", "claude-sonnet-4-5", {"_callbackId": "cb1"})
+            result = await handler._generate_async("run123", "claude-sonnet-4-6", {"_callbackId": "cb1"})
             assert result["type"] == "error"
             assert "not found" in result["message"]
 
@@ -629,7 +629,7 @@ class TestNativeHostGenerateAsync:
                 with patch("reverse_api.native_host.send_message"):
                     with patch("reverse_api.engineer.ClaudeEngineer", return_value=mock_engineer):
                         result = await handler._generate_async(
-                            "run123", "claude-sonnet-4-5", {"_callbackId": "cb1"}
+                            "run123", "claude-sonnet-4-6", {"_callbackId": "cb1"}
                         )
                         assert result["type"] == "error"
                         assert result["retryable"] is True
@@ -657,7 +657,7 @@ class TestNativeHostGenerateAsync:
                     with patch("reverse_api.engineer.ClaudeEngineer", return_value=mock_engineer):
                         with patch("reverse_api.session.SessionManager"):
                             result = await handler._generate_async(
-                                "run123", "claude-sonnet-4-5", {"_callbackId": "cb1"}
+                                "run123", "claude-sonnet-4-6", {"_callbackId": "cb1"}
                             )
                             assert result["type"] == "complete"
 
@@ -668,7 +668,7 @@ class TestNativeHostChatAsync:
     def _make_handler(self):
         with patch("reverse_api.native_host.ConfigManager") as mock_cm:
             mock_cm.return_value.config_path = Path("/test/config.json")
-            mock_cm.return_value.get.return_value = "claude-sonnet-4-5"
+            mock_cm.return_value.get.return_value = "claude-sonnet-4-6"
             handler = NativeHostHandler()
             handler.config = mock_cm.return_value
             return handler

--- a/tests/test_opencode_engineer.py
+++ b/tests/test_opencode_engineer.py
@@ -148,8 +148,8 @@ class TestOpenCodeEngineerModelMap:
 
     def test_model_map(self):
         """MODEL_MAP has expected entries."""
-        assert OpenCodeEngineer.MODEL_MAP["sonnet"] == "claude-sonnet-4-5"
-        assert OpenCodeEngineer.MODEL_MAP["opus"] == "claude-opus-4-5"
+        assert OpenCodeEngineer.MODEL_MAP["sonnet"] == "claude-sonnet-4-6"
+        assert OpenCodeEngineer.MODEL_MAP["opus"] == "claude-opus-4-6"
         assert OpenCodeEngineer.MODEL_MAP["haiku"] == "claude-haiku-4-5"
 
 
@@ -170,10 +170,10 @@ class TestOpenCodeEngineerInit:
                         prompt="test prompt",
                         output_dir=str(tmp_path),
                         opencode_provider="anthropic",
-                        opencode_model="claude-opus-4-5",
+                        opencode_model="claude-opus-4-6",
                     )
                     assert eng.opencode_provider == "anthropic"
-                    assert eng.opencode_model == "claude-opus-4-5"
+                    assert eng.opencode_model == "claude-opus-4-6"
                     assert eng._session_id is None
 
     def test_init_default_opencode_kwargs(self, tmp_path):
@@ -191,7 +191,7 @@ class TestOpenCodeEngineerInit:
                         output_dir=str(tmp_path),
                     )
                     assert eng.opencode_provider == "anthropic"
-                    assert eng.opencode_model == "claude-opus-4-5"
+                    assert eng.opencode_model == "claude-opus-4-6"
 
 
 class TestOpenCodeEngineerAuth:
@@ -1201,7 +1201,7 @@ class TestOpenCodeEngineerAnalyzeAndGenerate:
         messages_response.status_code = 200
         messages_response.json.return_value = [
             {
-                "info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-sonnet-4-5"},
+                "info": {"role": "assistant", "providerID": "anthropic", "modelID": "claude-sonnet-4-6"},
                 "parts": [{"type": "text", "text": "Here is the API client."}],
             }
         ]

--- a/tests/test_opencode_ui.py
+++ b/tests/test_opencode_ui.py
@@ -30,7 +30,7 @@ class TestOpenCodeUI:
     def test_header(self):
         """Header displays info."""
         ui, console = self._make_ui()
-        ui.header("run123", "test prompt", "claude-opus-4-5", "opencode")
+        ui.header("run123", "test prompt", "claude-opus-4-6", "opencode")
         output = console.file.getvalue()
         assert "run123" in output
         assert "test prompt" in output
@@ -38,7 +38,7 @@ class TestOpenCodeUI:
     def test_header_no_sdk(self):
         """Header without sdk."""
         ui, console = self._make_ui()
-        ui.header("run123", "test prompt", "claude-opus-4-5")
+        ui.header("run123", "test prompt", "claude-opus-4-6")
         output = console.file.getvalue()
         assert "run123" in output
 
@@ -66,10 +66,10 @@ class TestOpenCodeUI:
     def test_model_info(self):
         """Model info shows provider/model."""
         ui, console = self._make_ui()
-        ui.model_info("anthropic", "claude-sonnet-4-5")
+        ui.model_info("anthropic", "claude-sonnet-4-6")
         output = console.file.getvalue()
         assert "anthropic" in output
-        assert "claude-sonnet-4-5" in output
+        assert "claude-sonnet-4-6" in output
 
     def test_start_and_stop_streaming(self):
         """Streaming can be started and stopped."""

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -18,8 +18,8 @@ class TestModelPricing:
 
     def test_has_claude_models(self):
         """All Claude models are in pricing."""
-        assert "claude-sonnet-4-5" in MODEL_PRICING
-        assert "claude-opus-4-5" in MODEL_PRICING
+        assert "claude-sonnet-4-6" in MODEL_PRICING
+        assert "claude-opus-4-6" in MODEL_PRICING
         assert "claude-haiku-4-5" in MODEL_PRICING
 
     def test_has_gemini_models(self):
@@ -31,12 +31,12 @@ class TestModelPricing:
 
     def test_has_thinking_models(self):
         """Thinking model variants are in pricing."""
-        assert "claude-sonnet-4-5-thinking-low" in MODEL_PRICING
-        assert "claude-sonnet-4-5-thinking-medium" in MODEL_PRICING
-        assert "claude-sonnet-4-5-thinking-high" in MODEL_PRICING
-        assert "claude-opus-4-5-thinking-low" in MODEL_PRICING
-        assert "claude-opus-4-5-thinking-medium" in MODEL_PRICING
-        assert "claude-opus-4-5-thinking-high" in MODEL_PRICING
+        assert "claude-sonnet-4-6-thinking-low" in MODEL_PRICING
+        assert "claude-sonnet-4-6-thinking-medium" in MODEL_PRICING
+        assert "claude-sonnet-4-6-thinking-high" in MODEL_PRICING
+        assert "claude-opus-4-6-thinking-low" in MODEL_PRICING
+        assert "claude-opus-4-6-thinking-medium" in MODEL_PRICING
+        assert "claude-opus-4-6-thinking-high" in MODEL_PRICING
 
     def test_pricing_keys(self):
         """Each model has required pricing keys."""
@@ -52,13 +52,13 @@ class TestModelPricing:
 
     def test_opus_more_expensive_than_sonnet(self):
         """Opus should be more expensive than Sonnet."""
-        assert MODEL_PRICING["claude-opus-4-5"]["input"] > MODEL_PRICING["claude-sonnet-4-5"]["input"]
-        assert MODEL_PRICING["claude-opus-4-5"]["output"] > MODEL_PRICING["claude-sonnet-4-5"]["output"]
+        assert MODEL_PRICING["claude-opus-4-6"]["input"] > MODEL_PRICING["claude-sonnet-4-6"]["input"]
+        assert MODEL_PRICING["claude-opus-4-6"]["output"] > MODEL_PRICING["claude-sonnet-4-6"]["output"]
 
     def test_haiku_cheapest_claude(self):
         """Haiku should be cheapest Claude model."""
-        assert MODEL_PRICING["claude-haiku-4-5"]["input"] < MODEL_PRICING["claude-sonnet-4-5"]["input"]
-        assert MODEL_PRICING["claude-haiku-4-5"]["output"] < MODEL_PRICING["claude-sonnet-4-5"]["output"]
+        assert MODEL_PRICING["claude-haiku-4-5"]["input"] < MODEL_PRICING["claude-sonnet-4-6"]["input"]
+        assert MODEL_PRICING["claude-haiku-4-5"]["output"] < MODEL_PRICING["claude-sonnet-4-6"]["output"]
 
 
 class TestGetModelPricing:
@@ -66,7 +66,7 @@ class TestGetModelPricing:
 
     def test_known_model(self):
         """Returns pricing for known model."""
-        pricing = get_model_pricing("claude-sonnet-4-5")
+        pricing = get_model_pricing("claude-sonnet-4-6")
         assert pricing is not None
         assert pricing["input"] == 3.00
         assert pricing["output"] == 15.00
@@ -98,7 +98,7 @@ class TestGetPricingFromLitellm:
     def test_litellm_with_direct_match(self):
         """Returns pricing for direct model match."""
         mock_model_cost = {
-            "claude-sonnet-4-5": {
+            "claude-sonnet-4-6": {
                 "input_cost_per_token": 3e-06,
                 "output_cost_per_token": 15e-06,
                 "cache_creation_input_token_cost": 3.75e-06,
@@ -108,7 +108,7 @@ class TestGetPricingFromLitellm:
         mock_litellm = MagicMock()
         mock_litellm.model_cost = mock_model_cost
         with patch.dict("sys.modules", {"litellm": mock_litellm}):
-            result = _get_pricing_from_litellm("claude-sonnet-4-5")
+            result = _get_pricing_from_litellm("claude-sonnet-4-6")
             assert result is not None
             assert abs(result["input"] - 3.0) < 0.01
             assert abs(result["output"] - 15.0) < 0.01
@@ -116,7 +116,7 @@ class TestGetPricingFromLitellm:
     def test_litellm_with_mapped_model(self):
         """Returns pricing via model name mapping."""
         mock_model_cost = {
-            "anthropic.claude-sonnet-4-5": {
+            "anthropic.claude-sonnet-4-6": {
                 "input_cost_per_token": 3e-06,
                 "output_cost_per_token": 15e-06,
                 "cache_creation_input_token_cost": 3.75e-06,
@@ -126,7 +126,7 @@ class TestGetPricingFromLitellm:
         mock_litellm = MagicMock()
         mock_litellm.model_cost = mock_model_cost
         with patch.dict("sys.modules", {"litellm": mock_litellm}):
-            result = _get_pricing_from_litellm("claude-sonnet-4-5")
+            result = _get_pricing_from_litellm("claude-sonnet-4-6")
             assert result is not None
 
     def test_litellm_model_not_found(self):
@@ -173,8 +173,8 @@ class TestLitellmModelMap:
 
     def test_map_has_claude_models(self):
         """Map includes Claude model variations."""
-        assert "claude-sonnet-4-5" in _LITELLM_MODEL_MAP
-        assert "claude-opus-4-5" in _LITELLM_MODEL_MAP
+        assert "claude-sonnet-4-6" in _LITELLM_MODEL_MAP
+        assert "claude-opus-4-6" in _LITELLM_MODEL_MAP
         assert "claude-haiku-4-5" in _LITELLM_MODEL_MAP
 
     def test_map_has_gemini_models(self):
@@ -195,7 +195,7 @@ class TestCalculateCost:
     def test_known_model_basic(self):
         """Calculate cost for a known model with basic tokens."""
         cost = calculate_cost(
-            model_id="claude-sonnet-4-5",
+            model_id="claude-sonnet-4-6",
             input_tokens=1_000_000,
             output_tokens=1_000_000,
         )
@@ -204,13 +204,13 @@ class TestCalculateCost:
 
     def test_zero_tokens(self):
         """Zero tokens gives zero cost."""
-        cost = calculate_cost(model_id="claude-sonnet-4-5")
+        cost = calculate_cost(model_id="claude-sonnet-4-6")
         assert cost == 0.0
 
     def test_cache_tokens(self):
         """Cache tokens are included in cost."""
         cost = calculate_cost(
-            model_id="claude-sonnet-4-5",
+            model_id="claude-sonnet-4-6",
             cache_creation_tokens=1_000_000,
             cache_read_tokens=1_000_000,
         )
@@ -220,7 +220,7 @@ class TestCalculateCost:
     def test_reasoning_tokens(self):
         """Reasoning tokens are included in cost."""
         cost = calculate_cost(
-            model_id="claude-sonnet-4-5",
+            model_id="claude-sonnet-4-6",
             reasoning_tokens=1_000_000,
         )
         # Reasoning: 1M * $15/M = $15
@@ -229,7 +229,7 @@ class TestCalculateCost:
     def test_all_token_types(self):
         """All token types contribute to cost."""
         cost = calculate_cost(
-            model_id="claude-sonnet-4-5",
+            model_id="claude-sonnet-4-6",
             input_tokens=1_000_000,
             output_tokens=1_000_000,
             cache_creation_tokens=1_000_000,
@@ -240,7 +240,7 @@ class TestCalculateCost:
         assert abs(cost - expected) < 0.01
 
     def test_unknown_model_falls_back_to_sonnet(self):
-        """Unknown model uses Claude Sonnet 4.5 pricing."""
+        """Unknown model uses Claude Sonnet 4.6 pricing."""
         with patch("reverse_api.pricing._get_pricing_from_litellm", return_value=None):
             cost = calculate_cost(
                 model_id="unknown-model",
@@ -250,7 +250,7 @@ class TestCalculateCost:
             assert abs(cost - 3.0) < 0.01
 
     def test_none_model_falls_back_to_sonnet(self):
-        """None model uses Claude Sonnet 4.5 pricing."""
+        """None model uses Claude Sonnet 4.6 pricing."""
         cost = calculate_cost(
             model_id=None,
             input_tokens=1_000_000,
@@ -277,7 +277,7 @@ class TestCalculateCost:
     def test_small_token_counts(self):
         """Small token counts give proportional costs."""
         cost = calculate_cost(
-            model_id="claude-sonnet-4-5",
+            model_id="claude-sonnet-4-6",
             input_tokens=1000,
             output_tokens=500,
         )
@@ -286,6 +286,6 @@ class TestCalculateCost:
 
     def test_haiku_cheaper(self):
         """Haiku model should be cheaper for same tokens."""
-        sonnet_cost = calculate_cost("claude-sonnet-4-5", input_tokens=1_000_000, output_tokens=1_000_000)
+        sonnet_cost = calculate_cost("claude-sonnet-4-6", input_tokens=1_000_000, output_tokens=1_000_000)
         haiku_cost = calculate_cost("claude-haiku-4-5", input_tokens=1_000_000, output_tokens=1_000_000)
         assert haiku_cost < sonnet_cost

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -50,7 +50,7 @@ class TestSessionManagerAddRun:
             "run1",
             "test prompt",
             url="https://example.com",
-            model="claude-sonnet-4-5",
+            model="claude-sonnet-4-6",
             mode="agent",
             sdk="claude",
             output_mode="docs",
@@ -59,7 +59,7 @@ class TestSessionManagerAddRun:
         )
         run = sm.history[0]
         assert run["url"] == "https://example.com"
-        assert run["model"] == "claude-sonnet-4-5"
+        assert run["model"] == "claude-sonnet-4-6"
         assert run["mode"] == "agent"
         assert run["sdk"] == "claude"
         assert run["output_mode"] == "docs"
@@ -117,9 +117,9 @@ class TestSessionManagerUpdateRun:
         """Update arbitrary fields for an existing run."""
         sm = SessionManager(history_path)
         sm.add_run("run1", "test")
-        sm.update_run("run1", model="claude-opus-4-5", status="complete")
+        sm.update_run("run1", model="claude-opus-4-6", status="complete")
         run = sm.get_run("run1")
-        assert run["model"] == "claude-opus-4-5"
+        assert run["model"] == "claude-opus-4-6"
         assert run["status"] == "complete"
 
     def test_update_nonexistent_run(self, history_path):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -43,7 +43,7 @@ class TestClaudeUI:
     def test_header(self):
         """Header displays run info."""
         ui, console = self._make_ui()
-        ui.header("run123", "test prompt", "claude-sonnet-4-5", "claude")
+        ui.header("run123", "test prompt", "claude-sonnet-4-6", "claude")
         output = console.file.getvalue()
         assert "run123" in output
         assert "test prompt" in output
@@ -51,7 +51,7 @@ class TestClaudeUI:
     def test_header_no_sdk(self):
         """Header without sdk shows model differently."""
         ui, console = self._make_ui()
-        ui.header("run123", "test prompt", "claude-sonnet-4-5")
+        ui.header("run123", "test prompt", "claude-sonnet-4-6")
         output = console.file.getvalue()
         assert "run123" in output
 
@@ -295,12 +295,12 @@ class TestGetModelChoices:
     def test_includes_sonnet(self):
         """Includes Sonnet model."""
         values = [c["value"] for c in get_model_choices()]
-        assert "claude-sonnet-4-5" in values
+        assert "claude-sonnet-4-6" in values
 
     def test_includes_opus(self):
         """Includes Opus model."""
         values = [c["value"] for c in get_model_choices()]
-        assert "claude-opus-4-5" in values
+        assert "claude-opus-4-6" in values
 
 
 class TestDisplayBanner:
@@ -316,7 +316,7 @@ class TestDisplayBanner:
     def test_banner_with_sdk_and_model(self):
         """Banner with SDK and model info."""
         console = Console(file=StringIO(), no_color=True)
-        display_banner(console, sdk="claude", model="claude-sonnet-4-5")
+        display_banner(console, sdk="claude", model="claude-sonnet-4-6")
         output = console.file.getvalue()
         assert "claude" in output
 


### PR DESCRIPTION
Replace claude-sonnet-4-5 with claude-sonnet-4-6 and claude-opus-4-5 with claude-opus-4-6 across all source, test, and documentation files. Haiku remains at 4.5. All 593 tests pass.

https://claude.ai/code/session_01NpqXTgmLVzt2tsHoGV1jmP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade default Claude models from 4.5 to 4.6 for Sonnet and Opus across the app. Pricing, fallbacks, CLI/TUI options, and Chrome extension defaults now use 4.6; Haiku stays on 4.5.

- **Dependencies**
  - Replaced `claude-sonnet-4-5` → `claude-sonnet-4-6` and `claude-opus-4-5` → `claude-opus-4-6` in source, tests, docs, and the Chrome extension defaults.
  - Updated pricing map (including thinking variants) and changed the fallback to `claude-sonnet-4-6`.
  - Updated CLI choices/help, TUI menu labels, and Stagehand Anthropic IDs; fixed stale examples in `src/reverse_api/cli.py` to `anthropic/claude-sonnet-4-6-20260301` and `anthropic/claude-opus-4-6-20260301`.

- **Migration**
  - Update any configs or scripts still using 4.5 IDs.
    - Edit `~/.reverse-api/config.json` (`claude_code_model`, `collector_model`, `opencode_model`) to use 4.6.
    - Update CLI args to `-m claude-sonnet-4-6` or `-m claude-opus-4-6`.
    - If using Stagehand, switch to `anthropic/claude-sonnet-4-6-20260301` or `anthropic/claude-opus-4-6-20260301`.

<sup>Written for commit 189e2a47c0714b358748f59426855fc7f68935db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cette PR effectue une mise à jour mécanique et cohérente des modèles Claude 4.5 vers 4.6 pour Sonnet et Opus dans tout le dépôt (sources Python et TypeScript, tests, extension Chrome, documentation). Haiku reste intentionnellement en 4.5.

**Points clés validés :**
- Remplacement global de `claude-sonnet-4-5` → `claude-sonnet-4-6` et `claude-opus-4-5` → `claude-opus-4-6` dans tous les fichiers source, tests et documentation
- Mise à jour cohérente de `anthropic_cua_models` dans `browser.py` avec les identifiants datés corrects (`20260301`)
- Exemplesmiseàjourds dans `cli.py` (lignes 787 et 789) affichent les identifiants Stagehand corrects et cohérents avec la validation
- Mise à jour des prix dans `pricing.py` pour les variantes 4.6 et thinking
- Migration des configurations et CLI/TUI vers les nouvelles versions 4.6
- Tous les 593 tests passent

Aucune référence résiduelle à `claude-sonnet-4-5` ou `claude-opus-4-5` dans le code source ou les tests. La PR est complète et prête à merger.

<sub>Last reviewed commit: 189e2a4</sub>

<!-- /greptile_comment -->