### PR TITLE
Copilot SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ collector = [
     "markdownify>=0.12.0",
     "beautifulsoup4>=4.12.0",
 ]
+copilot = [
+    "github-copilot-sdk>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/kalil0321/reverse-api-engineer"

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -577,3 +577,137 @@ class OpenCodeAutoEngineer(OpenCodeEngineer):
                         debug_log(f"Cleaned up MCP server: {self.mcp_name}")
                 except Exception:
                     pass  # Ignore cleanup errors
+
+
+class CopilotAutoEngineer:
+    """Auto mode using Copilot SDK: LLM controls browser via MCP while reverse engineering.
+
+    Uses composition rather than inheritance since CopilotEngineer requires lazy imports.
+    Delegates to CopilotEngineer for the core logic and adds MCP browser integration.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        prompt: str,
+        copilot_model: str | None = None,
+        output_dir: str | None = None,
+        **kwargs: Any,
+    ):
+        from .copilot_engineer import CopilotEngineer
+
+        har_dir = get_har_dir(run_id, output_dir)
+        har_path = har_dir / "recording.har"
+
+        self._engineer = CopilotEngineer(
+            run_id=run_id,
+            har_path=har_path,
+            prompt=prompt,
+            copilot_model=copilot_model,
+            output_dir=output_dir,
+            **kwargs,
+        )
+        self.mcp_run_id = run_id
+
+    def start_sync(self) -> None:
+        self._engineer.start_sync()
+
+    def stop_sync(self) -> None:
+        self._engineer.stop_sync()
+
+    async def analyze_and_generate(self) -> dict[str, Any] | None:
+        """Run auto mode with Copilot SDK and MCP browser integration."""
+        try:
+            from copilot import CopilotClient
+        except ImportError:
+            self._engineer.ui.error("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'")
+            return None
+
+        eng = self._engineer
+        eng.ui.header(eng.run_id, eng.prompt, eng.copilot_model, eng.sdk)
+        eng.ui.start_analysis()
+
+        auto_prompt = ClaudeAutoEngineer._build_auto_prompt(eng)
+        eng.message_store.save_prompt(auto_prompt)
+
+        done_event = asyncio.Event()
+        accumulated_text: list[str] = []
+
+        def on_event(event: Any) -> None:
+            event_type = event.type.value if hasattr(event.type, "value") else str(event.type)
+
+            if event_type == "assistant.message_delta":
+                delta = ""
+                if hasattr(event, "data") and hasattr(event.data, "delta_content"):
+                    delta = event.data.delta_content or ""
+                if delta:
+                    accumulated_text.append(delta)
+                    eng.ui.thinking(delta)
+            elif event_type == "assistant.message":
+                if hasattr(event, "data") and hasattr(event.data, "usage"):
+                    usage = event.data.usage
+                    if isinstance(usage, dict):
+                        eng.usage_metadata["input_tokens"] = usage.get("prompt_tokens", 0)
+                        eng.usage_metadata["output_tokens"] = usage.get("completion_tokens", 0)
+            elif event_type == "session.idle":
+                done_event.set()
+
+        try:
+            client = CopilotClient(
+                {
+                    "auto_start": True,
+                    "use_logged_in_user": True,
+                }
+            )
+            await client.start()
+
+            mcp_config = {
+                "type": "stdio",
+                "command": "npx",
+                "args": [
+                    "rae-playwright-mcp@latest",
+                    "run-mcp-server",
+                    "--run-id",
+                    self.mcp_run_id,
+                ],
+            }
+
+            session = await client.create_session(
+                {
+                    "model": eng.copilot_model,
+                    "streaming": True,
+                    "infinite_sessions": {"enabled": True},
+                    "mcp_servers": {"playwright": mcp_config},
+                }
+            )
+
+            session.on(on_event)
+            await session.send({"prompt": auto_prompt})
+            await done_event.wait()
+
+            if accumulated_text:
+                eng.message_store.save_thinking("".join(accumulated_text))
+
+            script_path = str(eng.scripts_dir / eng._get_client_filename())
+            local_path = str(eng.local_scripts_dir / eng._get_client_filename()) if eng.local_scripts_dir else None
+            eng.ui.success(script_path, local_path)
+            eng.usage_metadata["estimated_cost_usd"] = 0.0
+
+            result: dict[str, Any] = {
+                "script_path": script_path,
+                "usage": eng.usage_metadata,
+            }
+            eng.message_store.save_result(result)
+            return result
+
+        except Exception as e:
+            error_msg = str(e)
+            eng.ui.error(error_msg)
+            eng.message_store.save_error(error_msg)
+
+            if "buffer size" in error_msg.lower() or "1048576" in error_msg or "exceeded maximum buffer" in error_msg.lower():
+                eng.ui.console.print("\n[yellow]Screenshot too large (exceeds 1MB limit)[/yellow]")
+                eng.ui.console.print("[dim]Tip: The AI should take element-specific screenshots instead of full-page screenshots.[/dim]")
+            else:
+                eng.ui.console.print("\n[dim]Make sure GitHub Copilot CLI is installed and you are logged in: gh auth login[/dim]")
+            return None

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -652,6 +652,7 @@ class CopilotAutoEngineer:
             elif event_type == "session.idle":
                 done_event.set()
 
+        client = None
         try:
             client = CopilotClient(
                 {
@@ -683,7 +684,14 @@ class CopilotAutoEngineer:
 
             session.on(on_event)
             await session.send({"prompt": auto_prompt})
-            await done_event.wait()
+
+            # Wait with timeout protection (10 minutes)
+            try:
+                await asyncio.wait_for(done_event.wait(), timeout=600)
+            except TimeoutError:
+                eng.ui.error("Session timed out (10 min)")
+                eng.message_store.save_error("Session timed out")
+                return None
 
             if accumulated_text:
                 eng.message_store.save_thinking("".join(accumulated_text))
@@ -711,3 +719,11 @@ class CopilotAutoEngineer:
             else:
                 eng.ui.console.print("\n[dim]Make sure GitHub Copilot CLI is installed and you are logged in: gh auth login[/dim]")
             return None
+
+        finally:
+            # Always stop the client to avoid resource leaks
+            if client is not None:
+                try:
+                    await client.stop()
+                except Exception:
+                    pass

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -631,6 +631,7 @@ class CopilotAutoEngineer:
         eng.message_store.save_prompt(auto_prompt)
 
         done_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
         accumulated_text: list[str] = []
 
         def on_event(event: Any) -> None:
@@ -650,7 +651,8 @@ class CopilotAutoEngineer:
                         eng.usage_metadata["input_tokens"] = usage.get("prompt_tokens", 0)
                         eng.usage_metadata["output_tokens"] = usage.get("completion_tokens", 0)
             elif event_type == "session.idle":
-                done_event.set()
+                # Use thread-safe call in case SDK invokes callback from a different thread
+                loop.call_soon_threadsafe(done_event.set)
 
         client = None
         try:

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -618,9 +618,11 @@ class CopilotAutoEngineer:
     async def analyze_and_generate(self) -> dict[str, Any] | None:
         """Run auto mode with Copilot SDK and MCP browser integration."""
         try:
-            from copilot import CopilotClient
+            from copilot import CopilotClient, PermissionHandler
         except ImportError:
-            self._engineer.ui.error("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'")
+            self._engineer.ui.error(
+                "GitHub Copilot SDK not installed. From source: uv sync --extra copilot. Installed: pip install 'reverse-api-engineer[copilot]'"
+            )
             return None
 
         eng = self._engineer
@@ -665,15 +667,33 @@ class CopilotAutoEngineer:
             await client.start()
 
             mcp_config = {
-                "type": "stdio",
+                "type": "local",
                 "command": "npx",
                 "args": [
+                    "-y",
                     "rae-playwright-mcp@latest",
                     "run-mcp-server",
                     "--run-id",
                     self.mcp_run_id,
                 ],
+                "tools": ["*"],
+                "timeout": 30000,
             }
+
+            async def on_pre_tool_use(input: dict, invocation: dict) -> dict:
+                tool_name = input.get("toolName", "unknown")
+                tool_args = input.get("toolArgs") or {}
+                eng.ui.tool_start(tool_name, tool_args)
+                eng.message_store.save_tool_start(tool_name, tool_args)
+                return {"permissionDecision": "allow", "modifiedArgs": tool_args}
+
+            async def on_post_tool_use(input: dict, invocation: dict) -> dict:
+                tool_name = input.get("toolName", "unknown")
+                is_error = invocation.get("resultType") == "error" if isinstance(invocation, dict) else False
+                output = invocation.get("result") if isinstance(invocation, dict) else None
+                eng.ui.tool_result(tool_name, is_error=is_error, output=str(output) if output else None)
+                eng.message_store.save_tool_result(tool_name, is_error, str(output) if output else None)
+                return {}
 
             session = await client.create_session(
                 {
@@ -681,6 +701,11 @@ class CopilotAutoEngineer:
                     "streaming": True,
                     "infinite_sessions": {"enabled": True},
                     "mcp_servers": {"playwright": mcp_config},
+                    "on_permission_request": PermissionHandler.approve_all,
+                    "hooks": {
+                        "on_pre_tool_use": on_pre_tool_use,
+                        "on_post_tool_use": on_post_tool_use,
+                    },
                 }
             )
 

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -680,7 +680,7 @@ class CopilotAutoEngineer:
                 "timeout": 30000,
             }
 
-            async def on_pre_tool_use(input: dict, invocation: dict) -> dict:
+            async def on_pre_tool_use(input: dict, _invocation: dict) -> dict:
                 tool_name = input.get("toolName", "unknown")
                 tool_args = input.get("toolArgs") or {}
                 eng.ui.tool_start(tool_name, tool_args)

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -4,9 +4,11 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+import questionary
+
 from .messages import MessageStore
 from .sync import FileSyncWatcher, get_available_directory
-from .tui import ClaudeUI
+from .tui import THEME_PRIMARY, THEME_SECONDARY, ClaudeUI
 from .utils import generate_folder_name, get_docs_dir, get_scripts_dir
 
 
@@ -102,6 +104,122 @@ class BaseEngineer(ABC):
         if self.sync_watcher:
             return self.sync_watcher.get_status()
         return None
+
+    async def _ask_user_interactive(self, questions: list[dict[str, Any]]) -> dict[str, str]:
+        """Prompt the user interactively for answers to questions.
+
+        Shared logic used by both ClaudeEngineer and CopilotEngineer.
+
+        Args:
+            questions: List of question dicts with keys: question, header, options, multiSelect
+
+        Returns:
+            Dict mapping question text to user's answer string.
+        """
+        answers: dict[str, str] = {}
+
+        self.ui.console.print()
+        self.ui.console.print(f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]")
+        self.ui.console.print()
+
+        for q in questions:
+            question_text = q.get("question", "") if isinstance(q, dict) else getattr(q, "question", "")
+            header = q.get("header", "") if isinstance(q, dict) else getattr(q, "header", "")
+            options = q.get("options", []) if isinstance(q, dict) else getattr(q, "options", [])
+            multi_select = q.get("multiSelect", False) if isinstance(q, dict) else getattr(q, "multiSelect", False)
+
+            if not question_text:
+                continue
+
+            if header:
+                self.ui.console.print(f"  [dim]{header}[/dim]")
+
+            try:
+                if multi_select:
+                    choices = [
+                        f"{self._get_opt_field(opt, 'label')} - {self._get_opt_field(opt, 'description')}"
+                        if self._get_opt_field(opt, "description")
+                        else self._get_opt_field(opt, "label")
+                        for opt in options
+                    ]
+                    if choices:
+                        selected = await questionary.checkbox(
+                            f" > {question_text}",
+                            choices=choices,
+                            qmark="",
+                            style=questionary.Style(
+                                [
+                                    ("pointer", f"fg:{THEME_PRIMARY} bold"),
+                                    ("highlighted", f"fg:{THEME_PRIMARY} bold"),
+                                    ("selected", f"fg:{THEME_PRIMARY}"),
+                                ]
+                            ),
+                        ).ask_async()
+
+                        if selected is None:
+                            raise KeyboardInterrupt
+
+                        labels = [s.split(" - ")[0] if " - " in s else s for s in selected]
+                        answers[question_text] = ", ".join(labels)
+                    else:
+                        answer = await questionary.text(
+                            f" > {question_text}",
+                            qmark="",
+                            style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
+                        ).ask_async()
+                        if answer is None:
+                            raise KeyboardInterrupt
+                        answers[question_text] = answer.strip()
+                else:
+                    choices = [
+                        f"{self._get_opt_field(opt, 'label')} - {self._get_opt_field(opt, 'description')}"
+                        if self._get_opt_field(opt, "description")
+                        else self._get_opt_field(opt, "label")
+                        for opt in options
+                    ]
+                    if choices:
+                        answer = await questionary.select(
+                            f" > {question_text}",
+                            choices=choices,
+                            qmark="",
+                            style=questionary.Style(
+                                [
+                                    ("pointer", f"fg:{THEME_PRIMARY} bold"),
+                                    ("highlighted", f"fg:{THEME_PRIMARY} bold"),
+                                ]
+                            ),
+                        ).ask_async()
+
+                        if answer is None:
+                            raise KeyboardInterrupt
+
+                        label = answer.split(" - ")[0] if " - " in answer else answer
+                        answers[question_text] = label
+                    else:
+                        answer = await questionary.text(
+                            f" > {question_text}",
+                            qmark="",
+                            style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
+                        ).ask_async()
+                        if answer is None:
+                            raise KeyboardInterrupt
+                        answers[question_text] = answer.strip()
+
+                self.ui.console.print(f"  [dim]→ {answers[question_text]}[/dim]")
+
+            except KeyboardInterrupt:
+                self.ui.console.print("  [dim]User cancelled question[/dim]")
+                answers[question_text] = ""
+
+        self.ui.console.print()
+        return answers
+
+    @staticmethod
+    def _get_opt_field(opt: Any, field: str) -> str:
+        """Get a field from an option, supporting both dict and object access."""
+        if isinstance(opt, dict):
+            return opt.get(field, "")
+        return getattr(opt, field, "")
 
     def _get_output_extension(self) -> str:
         """Return file extension based on output language."""
@@ -333,7 +451,9 @@ Here is the output directory where you should save your generated files:
 </output_dir>
 
 **IMPORTANT: You have access to the AskUserQuestion tool to ask clarifying questions during your analysis.**
-Use this tool when you need to clarify functional requirements, prioritize features, choose between implementation approaches, or gather any other information that would help you generate better {task_description}.
+Use this tool when you need to clarify functional requirements, prioritize features, choose between implementation approaches, or gather any other information that would help you generate better {
+            task_description
+        }.
 
 Your task is to:
 
@@ -378,7 +498,10 @@ In your scratchpad:
 - Identify any ambiguities or questions you should ask the user using AskUserQuestion
 </scratchpad>
 
-{"" if self.output_mode == "docs" else """If your first attempt doesn't work, analyze what went wrong and try again. Document each attempt and what you learned.
+{
+            ""
+            if self.output_mode == "docs"
+            else '''If your first attempt doesn't work, analyze what went wrong and try again. Document each attempt and what you learned.
 
 <attempt_log>
 For each attempt (up to 5), document:
@@ -388,7 +511,8 @@ For each attempt (up to 5), document:
 - What you changed for the next attempt
 </attempt_log>
 
-"""}After {"documenting" if self.output_mode == "docs" else "testing"}, provide your final response with:
+'''
+        }After {"documenting" if self.output_mode == "docs" else "testing"}, provide your final response with:
 - A summary of the APIs discovered
 - The authentication method used
 - {"The completeness and accuracy of the OpenAPI spec" if self.output_mode == "docs" else "Whether the implementation works"}
@@ -396,7 +520,9 @@ For each attempt (up to 5), document:
 - The paths to the generated files
 
 Your final output should confirm that the files have been created and provide a brief summary of what was accomplished.
-Do not include the full {"spec" if self.output_mode == "docs" else "code"} in your response - just confirm the files were saved and summarize the key findings.
+Do not include the full {
+            "spec" if self.output_mode == "docs" else "code"
+        } in your response - just confirm the files were saved and summarize the key findings.
 """
         if self.additional_instructions:
             base_prompt += f"\n\nAdditional instructions:\n{self.additional_instructions}"

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -433,6 +433,21 @@ Your OpenAPI spec should be production-ready and suitable for:
             mode_description = f"reverse engineer API calls and generate production-ready {language_name} code that replicates"
             task_description = f"{language_name} API client"
 
+        attempt_log_section = "" if self.output_mode == "docs" else (
+            "If your first attempt doesn't work, analyze what went wrong and try again. "
+            "Document each attempt and what you learned.\n\n"
+            "<attempt_log>\n"
+            "For each attempt (up to 5), document:\n"
+            "- Attempt number\n"
+            "- What approach you tried\n"
+            "- What error or issue occurred (if any)\n"
+            "- What you changed for the next attempt\n"
+            "</attempt_log>\n\n"
+        )
+        after_verb = "documenting" if self.output_mode == "docs" else "testing"
+        output_type = "spec" if self.output_mode == "docs" else "code"
+        quality_check = "The completeness and accuracy of the OpenAPI spec" if self.output_mode == "docs" else "Whether the implementation works"
+
         base_prompt = f"""You are tasked with analyzing a HAR (HTTP Archive) file to {mode_description} those calls.
 
 Here is the HAR file path you need to analyze:
@@ -451,9 +466,7 @@ Here is the output directory where you should save your generated files:
 </output_dir>
 
 **IMPORTANT: You have access to the AskUserQuestion tool to ask clarifying questions during your analysis.**
-Use this tool when you need to clarify functional requirements, prioritize features, choose between implementation approaches, or gather any other information that would help you generate better {
-            task_description
-        }.
+Use this tool when you need to clarify functional requirements, prioritize features, choose between implementation approaches, or gather any other information that would help you generate better {task_description}.
 
 Your task is to:
 
@@ -498,31 +511,15 @@ In your scratchpad:
 - Identify any ambiguities or questions you should ask the user using AskUserQuestion
 </scratchpad>
 
-{
-            ""
-            if self.output_mode == "docs"
-            else '''If your first attempt doesn't work, analyze what went wrong and try again. Document each attempt and what you learned.
-
-<attempt_log>
-For each attempt (up to 5), document:
-- Attempt number
-- What approach you tried
-- What error or issue occurred (if any)
-- What you changed for the next attempt
-</attempt_log>
-
-'''
-        }After {"documenting" if self.output_mode == "docs" else "testing"}, provide your final response with:
+{attempt_log_section}After {after_verb}, provide your final response with:
 - A summary of the APIs discovered
 - The authentication method used
-- {"The completeness and accuracy of the OpenAPI spec" if self.output_mode == "docs" else "Whether the implementation works"}
+- {quality_check}
 - Any limitations or caveats
 - The paths to the generated files
 
 Your final output should confirm that the files have been created and provide a brief summary of what was accomplished.
-Do not include the full {
-            "spec" if self.output_mode == "docs" else "code"
-        } in your response - just confirm the files were saved and summarize the key findings.
+Do not include the full {output_type} in your response - just confirm the files were saved and summarize the key findings.
 """
         if self.additional_instructions:
             base_prompt += f"\n\nAdditional instructions:\n{self.additional_instructions}"

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -357,6 +357,8 @@ def repl_loop():
     sdk = config_manager.get("sdk", "claude")
     if sdk == "opencode":
         model = config_manager.get("opencode_model", "claude-opus-4-6")
+    elif sdk == "copilot":
+        model = config_manager.get("copilot_model", "gpt-5")
     else:
         model = config_manager.get("claude_code_model", "claude-sonnet-4-6")
 
@@ -553,6 +555,7 @@ def handle_settings(mode_color=THEME_PRIMARY):
         Choice(title="Agent Provider", value="agent_provider"),
         Choice(title="Browser-Use Model", value="browser_use_model"),
         Choice(title="Claude Code Model", value="claude_code_model"),
+        Choice(title="Copilot Model", value="copilot_model"),
         Choice(title="OpenCode Model", value="opencode_model"),
         Choice(title="OpenCode Provider", value="opencode_provider"),
         Choice(title="Output Directory", value="output_dir"),
@@ -602,8 +605,9 @@ def handle_settings(mode_color=THEME_PRIMARY):
 
     elif action == "sdk":
         sdk_choices = [
-            Choice(title="opencode", value="opencode"),
             Choice(title="claude", value="claude"),
+            Choice(title="copilot", value="copilot"),
+            Choice(title="opencode", value="opencode"),
             Choice(title="back", value="back"),
         ]
         sdk = questionary.select(
@@ -689,6 +693,28 @@ def handle_settings(mode_color=THEME_PRIMARY):
             else:
                 config_manager.set("opencode_provider", new_provider)
                 console.print(f" [dim]updated[/dim] opencode provider: {new_provider}\n")
+
+    elif action == "copilot_model":
+        current = config_manager.get("copilot_model", "gpt-5")
+        new_model = questionary.text(
+            " > copilot model",
+            default=current or "gpt-5",
+            instruction="(e.g., 'gpt-5', 'gpt-4.1')",
+            qmark="",
+            style=questionary.Style(
+                [
+                    ("question", f"fg:{THEME_SECONDARY}"),
+                    ("instruction", f"fg:{THEME_DIM} italic"),
+                ]
+            ),
+        ).ask()
+        if new_model is not None:
+            new_model = new_model.strip()
+            if not new_model:
+                console.print(" [yellow]error:[/yellow] copilot model cannot be empty\n")
+            else:
+                config_manager.set("copilot_model", new_model)
+                console.print(f" [dim]updated[/dim] copilot model: {new_model}\n")
 
     elif action == "opencode_model":
         current = config_manager.get("opencode_model", "claude-opus-4-6")
@@ -1464,6 +1490,18 @@ def run_auto_capture(prompt=None, url=None, model=None, output_dir=None):
                 sdk=sdk,
                 output_language=output_language,
             )
+        elif sdk == "copilot":
+            from .auto_engineer import CopilotAutoEngineer
+
+            engineer = CopilotAutoEngineer(
+                run_id=run_id,
+                prompt=prompt,
+                copilot_model=config_manager.get("copilot_model", "gpt-5"),
+                output_dir=output_dir,
+                enable_sync=config_manager.get("real_time_sync", False),
+                sdk=sdk,
+                output_language=output_language,
+            )
         else:
             from .auto_engineer import ClaudeAutoEngineer
 
@@ -1604,6 +1642,21 @@ def run_engineer(
             sdk=sdk,
             opencode_provider=config_manager.get("opencode_provider", "anthropic"),
             opencode_model=config_manager.get("opencode_model", "claude-opus-4-6"),
+            enable_sync=enable_sync,
+            additional_instructions=additional_instructions,
+            is_fresh=is_fresh,
+            output_language=output_language,
+            output_mode=output_mode,
+        )
+    elif sdk == "copilot":
+        result = run_reverse_engineering(
+            run_id=run_id,
+            har_path=har_path,
+            prompt=prompt,
+            model=model,
+            output_dir=output_dir,
+            sdk=sdk,
+            copilot_model=config_manager.get("copilot_model", "gpt-5"),
             enable_sync=enable_sync,
             additional_instructions=additional_instructions,
             is_fresh=is_fresh,

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -9,12 +9,13 @@ DEFAULT_CONFIG = {
     "browser_use_model": "bu-llm",  # "bu-llm" or "{provider}/{model_name}" (e.g. "openai/gpt-5-mini")
     "claude_code_model": "claude-sonnet-4-6",
     "collector_model": "claude-sonnet-4-6",  # Model for collector mode
+    "copilot_model": "gpt-5",  # Model for Copilot SDK sessions
     "opencode_model": "claude-opus-4-6",
     "opencode_provider": "anthropic",
     "output_dir": None,  # None means use ~/.reverse-api/runs
     "output_language": "python",  # "python", "javascript", or "typescript"
     "real_time_sync": True,  # Enable real-time file sync during engineering
-    "sdk": "claude",  # "opencode" or "claude"
+    "sdk": "claude",  # "claude", "opencode", or "copilot"
     "stagehand_model": "openai/computer-use-preview-2025-03-11",  # "{provider}/{model_name}" format
 }
 

--- a/src/reverse_api/copilot_engineer.py
+++ b/src/reverse_api/copilot_engineer.py
@@ -72,6 +72,7 @@ class CopilotEngineer(BaseEngineer):
         self.message_store.save_prompt(prompt)
 
         done_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
         accumulated_text: list[str] = []
 
         def on_event(event: Any) -> None:
@@ -94,7 +95,8 @@ class CopilotEngineer(BaseEngineer):
                         self.usage_metadata["output_tokens"] = usage.get("completion_tokens", 0)
 
             elif event_type == "session.idle":
-                done_event.set()
+                # Use thread-safe call in case SDK invokes callback from a different thread
+                loop.call_soon_threadsafe(done_event.set)
 
             elif event_type == "session.compaction_start":
                 self.ui.console.print("  [dim]session compacting...[/dim]")

--- a/src/reverse_api/copilot_engineer.py
+++ b/src/reverse_api/copilot_engineer.py
@@ -3,10 +3,10 @@
 import asyncio
 from typing import Any
 
-import questionary
-
 from .base_engineer import BaseEngineer
-from .tui import THEME_PRIMARY, THEME_SECONDARY
+
+# Timeout for waiting on Copilot session completion (10 minutes)
+_SESSION_TIMEOUT = 600
 
 
 class CopilotEngineer(BaseEngineer):
@@ -45,93 +45,14 @@ class CopilotEngineer(BaseEngineer):
         class AskUserParams(BaseModel):
             questions: list[Question] = Field(description="Questions to ask the user")
 
-        ui = self.ui
+        # Capture self for use in the tool handler
+        engineer = self
 
         @define_tool(description="Ask the user a clarifying question. Use when you need user input to proceed.")  # type: ignore[misc]
         async def ask_user_question(params: AskUserParams) -> str:
-            answers: dict[str, str] = {}
-
-            ui.console.print()
-            ui.console.print(f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]")
-            ui.console.print()
-
-            for q in params.questions:
-                if not q.question:
-                    continue
-
-                if q.header:
-                    ui.console.print(f"  [dim]{q.header}[/dim]")
-
-                try:
-                    if q.multiSelect:
-                        choices = [f"{opt.label} - {opt.description}" if opt.description else opt.label for opt in q.options]
-                        if choices:
-                            selected = await questionary.checkbox(
-                                f" > {q.question}",
-                                choices=choices,
-                                qmark="",
-                                style=questionary.Style(
-                                    [
-                                        ("pointer", f"fg:{THEME_PRIMARY} bold"),
-                                        ("highlighted", f"fg:{THEME_PRIMARY} bold"),
-                                        ("selected", f"fg:{THEME_PRIMARY}"),
-                                    ]
-                                ),
-                            ).ask_async()
-
-                            if selected is None:
-                                raise KeyboardInterrupt
-
-                            labels = [s.split(" - ")[0] if " - " in s else s for s in selected]
-                            answers[q.question] = ", ".join(labels)
-                        else:
-                            answer = await questionary.text(
-                                f" > {q.question}",
-                                qmark="",
-                                style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
-                            ).ask_async()
-                            if answer is None:
-                                raise KeyboardInterrupt
-                            answers[q.question] = answer.strip()
-                    else:
-                        choices = [f"{opt.label} - {opt.description}" if opt.description else opt.label for opt in q.options]
-                        if choices:
-                            answer = await questionary.select(
-                                f" > {q.question}",
-                                choices=choices,
-                                qmark="",
-                                style=questionary.Style(
-                                    [
-                                        ("pointer", f"fg:{THEME_PRIMARY} bold"),
-                                        ("highlighted", f"fg:{THEME_PRIMARY} bold"),
-                                    ]
-                                ),
-                            ).ask_async()
-
-                            if answer is None:
-                                raise KeyboardInterrupt
-
-                            label = answer.split(" - ")[0] if " - " in answer else answer
-                            answers[q.question] = label
-                        else:
-                            answer = await questionary.text(
-                                f" > {q.question}",
-                                qmark="",
-                                style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
-                            ).ask_async()
-                            if answer is None:
-                                raise KeyboardInterrupt
-                            answers[q.question] = answer.strip()
-
-                    ui.console.print(f"  [dim]→ {answers[q.question]}[/dim]")
-
-                except KeyboardInterrupt:
-                    ui.console.print("  [dim]User cancelled question[/dim]")
-                    answers[q.question] = ""
-
-            ui.console.print()
-
-            # Return answers as formatted string
+            # Convert pydantic models to dicts for the shared method
+            question_dicts = [q.model_dump() for q in params.questions]
+            answers = await engineer._ask_user_interactive(question_dicts)
             return "\n".join(f"{k}: {v}" for k, v in answers.items())
 
         return ask_user_question
@@ -181,6 +102,7 @@ class CopilotEngineer(BaseEngineer):
             elif event_type == "session.compaction_complete":
                 self.ui.console.print("  [dim]session compaction complete[/dim]")
 
+        client = None
         try:
             ask_user_tool = self._build_ask_user_tool()
 
@@ -205,8 +127,13 @@ class CopilotEngineer(BaseEngineer):
 
             await session.send({"prompt": prompt})
 
-            # Wait for session to complete
-            await done_event.wait()
+            # Wait for session to complete with timeout protection
+            try:
+                await asyncio.wait_for(done_event.wait(), timeout=_SESSION_TIMEOUT)
+            except TimeoutError:
+                self.ui.error(f"Session timed out after {_SESSION_TIMEOUT // 60} minutes")
+                self.message_store.save_error("Session timed out")
+                return None
 
             # Save accumulated thinking text
             if accumulated_text:
@@ -217,7 +144,7 @@ class CopilotEngineer(BaseEngineer):
             local_path = str(self.local_scripts_dir / self._get_client_filename()) if self.local_scripts_dir else None
             self.ui.success(script_path, local_path)
 
-            # GitHub subscription: cost is 0 (included in Copilot subscription)
+            # GitHub subscription: cost is $0 (included in Copilot subscription)
             self.usage_metadata["estimated_cost_usd"] = 0.0
 
             # Display usage if available
@@ -243,3 +170,11 @@ class CopilotEngineer(BaseEngineer):
             self.message_store.save_error(str(e))
             self.ui.console.print("\n[dim]Make sure GitHub Copilot CLI is installed and you are logged in: gh auth login[/dim]")
             return None
+
+        finally:
+            # Always stop the client to avoid resource leaks
+            if client is not None:
+                try:
+                    await client.stop()
+                except Exception:
+                    pass

--- a/src/reverse_api/copilot_engineer.py
+++ b/src/reverse_api/copilot_engineer.py
@@ -1,0 +1,245 @@
+"""GitHub Copilot SDK implementation for reverse engineering."""
+
+import asyncio
+from typing import Any
+
+import questionary
+
+from .base_engineer import BaseEngineer
+from .tui import THEME_PRIMARY, THEME_SECONDARY
+
+
+class CopilotEngineer(BaseEngineer):
+    """Uses GitHub Copilot SDK to analyze HAR files and generate API scripts."""
+
+    def __init__(
+        self,
+        run_id: str,
+        har_path: Any,
+        prompt: str,
+        copilot_model: str | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(run_id=run_id, har_path=har_path, prompt=prompt, **kwargs)
+        self.copilot_model = copilot_model or "gpt-5"
+
+    def _build_ask_user_tool(self) -> Any:
+        """Build the ask_user_question custom tool for Copilot sessions."""
+        try:
+            from copilot import define_tool
+        except ImportError:
+            raise ImportError("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'") from None
+
+        from pydantic import BaseModel, Field
+
+        class QuestionOption(BaseModel):
+            label: str = Field(description="Display text for this option")
+            description: str = Field(default="", description="Explanation of what this option means")
+
+        class Question(BaseModel):
+            question: str = Field(description="The question to ask the user")
+            header: str = Field(default="", description="Short label for context")
+            options: list[QuestionOption] = Field(default_factory=list, description="Available choices")
+            multiSelect: bool = Field(default=False, description="Allow multiple selections")
+
+        class AskUserParams(BaseModel):
+            questions: list[Question] = Field(description="Questions to ask the user")
+
+        ui = self.ui
+
+        @define_tool(description="Ask the user a clarifying question. Use when you need user input to proceed.")  # type: ignore[misc]
+        async def ask_user_question(params: AskUserParams) -> str:
+            answers: dict[str, str] = {}
+
+            ui.console.print()
+            ui.console.print(f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]")
+            ui.console.print()
+
+            for q in params.questions:
+                if not q.question:
+                    continue
+
+                if q.header:
+                    ui.console.print(f"  [dim]{q.header}[/dim]")
+
+                try:
+                    if q.multiSelect:
+                        choices = [f"{opt.label} - {opt.description}" if opt.description else opt.label for opt in q.options]
+                        if choices:
+                            selected = await questionary.checkbox(
+                                f" > {q.question}",
+                                choices=choices,
+                                qmark="",
+                                style=questionary.Style(
+                                    [
+                                        ("pointer", f"fg:{THEME_PRIMARY} bold"),
+                                        ("highlighted", f"fg:{THEME_PRIMARY} bold"),
+                                        ("selected", f"fg:{THEME_PRIMARY}"),
+                                    ]
+                                ),
+                            ).ask_async()
+
+                            if selected is None:
+                                raise KeyboardInterrupt
+
+                            labels = [s.split(" - ")[0] if " - " in s else s for s in selected]
+                            answers[q.question] = ", ".join(labels)
+                        else:
+                            answer = await questionary.text(
+                                f" > {q.question}",
+                                qmark="",
+                                style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
+                            ).ask_async()
+                            if answer is None:
+                                raise KeyboardInterrupt
+                            answers[q.question] = answer.strip()
+                    else:
+                        choices = [f"{opt.label} - {opt.description}" if opt.description else opt.label for opt in q.options]
+                        if choices:
+                            answer = await questionary.select(
+                                f" > {q.question}",
+                                choices=choices,
+                                qmark="",
+                                style=questionary.Style(
+                                    [
+                                        ("pointer", f"fg:{THEME_PRIMARY} bold"),
+                                        ("highlighted", f"fg:{THEME_PRIMARY} bold"),
+                                    ]
+                                ),
+                            ).ask_async()
+
+                            if answer is None:
+                                raise KeyboardInterrupt
+
+                            label = answer.split(" - ")[0] if " - " in answer else answer
+                            answers[q.question] = label
+                        else:
+                            answer = await questionary.text(
+                                f" > {q.question}",
+                                qmark="",
+                                style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
+                            ).ask_async()
+                            if answer is None:
+                                raise KeyboardInterrupt
+                            answers[q.question] = answer.strip()
+
+                    ui.console.print(f"  [dim]→ {answers[q.question]}[/dim]")
+
+                except KeyboardInterrupt:
+                    ui.console.print("  [dim]User cancelled question[/dim]")
+                    answers[q.question] = ""
+
+            ui.console.print()
+
+            # Return answers as formatted string
+            return "\n".join(f"{k}: {v}" for k, v in answers.items())
+
+        return ask_user_question
+
+    async def analyze_and_generate(self) -> dict[str, Any] | None:
+        """Run the reverse engineering analysis with GitHub Copilot."""
+        try:
+            from copilot import CopilotClient
+        except ImportError:
+            self.ui.error("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'")
+            return None
+
+        self.ui.header(self.run_id, self.prompt, self.copilot_model, self.sdk)
+        self.ui.start_analysis()
+
+        prompt = self._build_analysis_prompt()
+        self.message_store.save_prompt(prompt)
+
+        done_event = asyncio.Event()
+        accumulated_text: list[str] = []
+
+        def on_event(event: Any) -> None:
+            event_type = event.type.value if hasattr(event.type, "value") else str(event.type)
+
+            if event_type == "assistant.message_delta":
+                delta = ""
+                if hasattr(event, "data") and hasattr(event.data, "delta_content"):
+                    delta = event.data.delta_content or ""
+                if delta:
+                    accumulated_text.append(delta)
+                    self.ui.thinking(delta)
+
+            elif event_type == "assistant.message":
+                # Extract usage if available
+                if hasattr(event, "data") and hasattr(event.data, "usage"):
+                    usage = event.data.usage
+                    if isinstance(usage, dict):
+                        self.usage_metadata["input_tokens"] = usage.get("prompt_tokens", 0)
+                        self.usage_metadata["output_tokens"] = usage.get("completion_tokens", 0)
+
+            elif event_type == "session.idle":
+                done_event.set()
+
+            elif event_type == "session.compaction_start":
+                self.ui.console.print("  [dim]session compacting...[/dim]")
+
+            elif event_type == "session.compaction_complete":
+                self.ui.console.print("  [dim]session compaction complete[/dim]")
+
+        try:
+            ask_user_tool = self._build_ask_user_tool()
+
+            client = CopilotClient(
+                {
+                    "auto_start": True,
+                    "use_logged_in_user": True,
+                }
+            )
+            await client.start()
+
+            session = await client.create_session(
+                {
+                    "model": self.copilot_model,
+                    "streaming": True,
+                    "infinite_sessions": {"enabled": True},
+                    "tools": [ask_user_tool],
+                }
+            )
+
+            session.on(on_event)
+
+            await session.send({"prompt": prompt})
+
+            # Wait for session to complete
+            await done_event.wait()
+
+            # Save accumulated thinking text
+            if accumulated_text:
+                self.message_store.save_thinking("".join(accumulated_text))
+
+            # Build result
+            script_path = str(self.scripts_dir / self._get_client_filename())
+            local_path = str(self.local_scripts_dir / self._get_client_filename()) if self.local_scripts_dir else None
+            self.ui.success(script_path, local_path)
+
+            # GitHub subscription: cost is 0 (included in Copilot subscription)
+            self.usage_metadata["estimated_cost_usd"] = 0.0
+
+            # Display usage if available
+            input_tokens = self.usage_metadata.get("input_tokens", 0)
+            output_tokens = self.usage_metadata.get("output_tokens", 0)
+            if input_tokens > 0 or output_tokens > 0:
+                self.ui.console.print("  [dim]Usage:[/dim]")
+                if input_tokens > 0:
+                    self.ui.console.print(f"  [dim]  input: {input_tokens:,} tokens[/dim]")
+                if output_tokens > 0:
+                    self.ui.console.print(f"  [dim]  output: {output_tokens:,} tokens[/dim]")
+                self.ui.console.print("  [dim]  cost: $0.00 (Copilot subscription)[/dim]")
+
+            result: dict[str, Any] = {
+                "script_path": script_path,
+                "usage": self.usage_metadata,
+            }
+            self.message_store.save_result(result)
+            return result
+
+        except Exception as e:
+            self.ui.error(str(e))
+            self.message_store.save_error(str(e))
+            self.ui.console.print("\n[dim]Make sure GitHub Copilot CLI is installed and you are logged in: gh auth login[/dim]")
+            return None

--- a/src/reverse_api/copilot_engineer.py
+++ b/src/reverse_api/copilot_engineer.py
@@ -28,7 +28,9 @@ class CopilotEngineer(BaseEngineer):
         try:
             from copilot import define_tool
         except ImportError:
-            raise ImportError("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'") from None
+            raise ImportError(
+                "GitHub Copilot SDK not installed. From source: uv sync --extra copilot. Installed: pip install 'reverse-api-engineer[copilot]'"
+            ) from None
 
         from pydantic import BaseModel, Field
 
@@ -60,9 +62,11 @@ class CopilotEngineer(BaseEngineer):
     async def analyze_and_generate(self) -> dict[str, Any] | None:
         """Run the reverse engineering analysis with GitHub Copilot."""
         try:
-            from copilot import CopilotClient
+            from copilot import CopilotClient, PermissionHandler
         except ImportError:
-            self.ui.error("GitHub Copilot SDK not installed. Install with: uv pip install 'reverse-api-engineer[copilot]'")
+            self.ui.error(
+                "GitHub Copilot SDK not installed. From source: uv sync --extra copilot. Installed: pip install 'reverse-api-engineer[copilot]'"
+            )
             return None
 
         self.ui.header(self.run_id, self.prompt, self.copilot_model, self.sdk)
@@ -122,6 +126,7 @@ class CopilotEngineer(BaseEngineer):
                     "streaming": True,
                     "infinite_sessions": {"enabled": True},
                     "tools": [ask_user_tool],
+                    "on_permission_request": PermissionHandler.approve_all,
                 }
             )
 

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -28,9 +28,7 @@ logging.getLogger("claude_agent_sdk._internal.transport.subprocess_cli").setLeve
 class ClaudeEngineer(BaseEngineer):
     """Uses Claude Agent SDK to analyze HAR files and generate Python API scripts."""
 
-    async def _handle_ask_user_question(
-        self, tool_name: str, input_params: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _handle_ask_user_question(self, tool_name: str, input_params: dict[str, Any]) -> dict[str, Any]:
         """Handle AskUserQuestion tool by prompting the user interactively."""
         if tool_name != "AskUserQuestion":
             # Default allow for other tools in acceptEdits mode
@@ -41,9 +39,7 @@ class ClaudeEngineer(BaseEngineer):
 
         # Display header
         self.ui.console.print()
-        self.ui.console.print(
-            f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]"
-        )
+        self.ui.console.print(f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]")
         self.ui.console.print()
 
         for q in questions:
@@ -63,9 +59,7 @@ class ClaudeEngineer(BaseEngineer):
                 if multi_select:
                     # Multi-select question
                     choices = [
-                        f"{opt.get('label', '')} - {opt.get('description', '')}"
-                        if opt.get("description")
-                        else opt.get("label", "")
+                        f"{opt.get('label', '')} - {opt.get('description', '')}" if opt.get("description") else opt.get("label", "")
                         for opt in options
                     ]
                     if choices:
@@ -86,10 +80,7 @@ class ClaudeEngineer(BaseEngineer):
                             raise KeyboardInterrupt
 
                         # Extract just the labels (before the " - " separator)
-                        labels = [
-                            s.split(" - ")[0] if " - " in s else s
-                            for s in selected
-                        ]
+                        labels = [s.split(" - ")[0] if " - " in s else s for s in selected]
                         answers[question_text] = ", ".join(labels)
                     else:
                         # Text input fallback
@@ -105,9 +96,7 @@ class ClaudeEngineer(BaseEngineer):
                 else:
                     # Single select question
                     choices = [
-                        f"{opt.get('label', '')} - {opt.get('description', '')}"
-                        if opt.get("description")
-                        else opt.get("label", "")
+                        f"{opt.get('label', '')} - {opt.get('description', '')}" if opt.get("description") else opt.get("label", "")
                         for opt in options
                     ]
                     if choices:
@@ -284,6 +273,7 @@ def run_reverse_engineering(
     sdk: str = "claude",
     opencode_provider: str | None = None,
     opencode_model: str | None = None,
+    copilot_model: str | None = None,
     enable_sync: bool = False,
     is_fresh: bool = False,
     output_language: str = "python",
@@ -292,9 +282,10 @@ def run_reverse_engineering(
     """Run reverse engineering with the specified SDK.
 
     Args:
-        sdk: "opencode" or "claude" - determines which SDK to use
+        sdk: "claude", "opencode", or "copilot" - determines which SDK to use
         opencode_provider: Provider ID for OpenCode (e.g., "anthropic")
         opencode_model: Model ID for OpenCode (e.g., "claude-sonnet-4-6")
+        copilot_model: Model ID for Copilot (e.g., "gpt-5")
         enable_sync: Enable real-time file syncing during engineering
         is_fresh: Whether to start fresh (ignore previous scripts)
         output_language: Target language - "python", "javascript", or "typescript"
@@ -318,6 +309,24 @@ def run_reverse_engineering(
             is_fresh=is_fresh,
             output_language=output_language,
             output_mode=output_mode,
+        )
+    elif sdk == "copilot":
+        from .copilot_engineer import CopilotEngineer
+
+        engineer = CopilotEngineer(
+            run_id=run_id,
+            har_path=har_path,
+            prompt=prompt,
+            model=model,
+            additional_instructions=additional_instructions,
+            output_dir=output_dir,
+            verbose=verbose,
+            enable_sync=enable_sync,
+            sdk=sdk,
+            is_fresh=is_fresh,
+            output_language=output_language,
+            output_mode=output_mode,
+            copilot_model=copilot_model,
         )
     else:
         engineer = ClaudeEngineer(

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -15,10 +15,7 @@ from claude_agent_sdk import (
     ToolUseBlock,
 )
 
-import questionary
-
 from .base_engineer import BaseEngineer
-from .tui import THEME_PRIMARY, THEME_SECONDARY
 
 # Suppress claude_agent_sdk logs
 logging.getLogger("claude_agent_sdk").setLevel(logging.WARNING)
@@ -35,107 +32,7 @@ class ClaudeEngineer(BaseEngineer):
             return {"behavior": "allow", "updatedInput": input_params}
 
         questions = input_params.get("questions", [])
-        answers = {}
-
-        # Display header
-        self.ui.console.print()
-        self.ui.console.print(f"  [{THEME_PRIMARY}]?[/{THEME_PRIMARY}] [bold white]Agent Question[/bold white]")
-        self.ui.console.print()
-
-        for q in questions:
-            question_text = q.get("question", "")
-            header = q.get("header", "")
-            options = q.get("options", [])
-            multi_select = q.get("multiSelect", False)
-
-            if not question_text:
-                continue
-
-            # Show context if header exists
-            if header:
-                self.ui.console.print(f"  [dim]{header}[/dim]")
-
-            try:
-                if multi_select:
-                    # Multi-select question
-                    choices = [
-                        f"{opt.get('label', '')} - {opt.get('description', '')}" if opt.get("description") else opt.get("label", "")
-                        for opt in options
-                    ]
-                    if choices:
-                        selected = await questionary.checkbox(
-                            f" > {question_text}",
-                            choices=choices,
-                            qmark="",
-                            style=questionary.Style(
-                                [
-                                    ("pointer", f"fg:{THEME_PRIMARY} bold"),
-                                    ("highlighted", f"fg:{THEME_PRIMARY} bold"),
-                                    ("selected", f"fg:{THEME_PRIMARY}"),
-                                ]
-                            ),
-                        ).ask_async()
-
-                        if selected is None:
-                            raise KeyboardInterrupt
-
-                        # Extract just the labels (before the " - " separator)
-                        labels = [s.split(" - ")[0] if " - " in s else s for s in selected]
-                        answers[question_text] = ", ".join(labels)
-                    else:
-                        # Text input fallback
-                        answer = await questionary.text(
-                            f" > {question_text}",
-                            qmark="",
-                            style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
-                        ).ask_async()
-                        if answer is None:
-                            raise KeyboardInterrupt
-                        answers[question_text] = answer.strip()
-
-                else:
-                    # Single select question
-                    choices = [
-                        f"{opt.get('label', '')} - {opt.get('description', '')}" if opt.get("description") else opt.get("label", "")
-                        for opt in options
-                    ]
-                    if choices:
-                        answer = await questionary.select(
-                            f" > {question_text}",
-                            choices=choices,
-                            qmark="",
-                            style=questionary.Style(
-                                [
-                                    ("pointer", f"fg:{THEME_PRIMARY} bold"),
-                                    ("highlighted", f"fg:{THEME_PRIMARY} bold"),
-                                ]
-                            ),
-                        ).ask_async()
-
-                        if answer is None:
-                            raise KeyboardInterrupt
-
-                        # Extract just the label (before the " - " separator)
-                        label = answer.split(" - ")[0] if " - " in answer else answer
-                        answers[question_text] = label
-                    else:
-                        # Text input fallback
-                        answer = await questionary.text(
-                            f" > {question_text}",
-                            qmark="",
-                            style=questionary.Style([("question", f"fg:{THEME_SECONDARY}")]),
-                        ).ask_async()
-                        if answer is None:
-                            raise KeyboardInterrupt
-                        answers[question_text] = answer.strip()
-
-                self.ui.console.print(f"  [dim]→ {answers[question_text]}[/dim]")
-
-            except KeyboardInterrupt:
-                self.ui.console.print(f"  [dim]User cancelled question[/dim]")
-                answers[question_text] = ""
-
-        self.ui.console.print()
+        answers = await self._ask_user_interactive(questions)
 
         return {
             "behavior": "allow",

--- a/src/reverse_api/pricing.py
+++ b/src/reverse_api/pricing.py
@@ -94,25 +94,25 @@ MODEL_PRICING = {
     },
     # GPT models (for Copilot SDK - cost is $0 with GitHub subscription)
     "gpt-5": {
-        "input": 2.00,
-        "output": 8.00,
+        "input": 0,
+        "output": 0,
         "cache_creation": 0,
         "cache_read": 0,
-        "reasoning": 8.00,
+        "reasoning": 0,
     },
     "gpt-4.1": {
-        "input": 2.00,
-        "output": 8.00,
+        "input": 0,
+        "output": 0,
         "cache_creation": 0,
         "cache_read": 0,
-        "reasoning": 8.00,
+        "reasoning": 0,
     },
     "gpt-4.1-mini": {
-        "input": 0.40,
-        "output": 1.60,
+        "input": 0,
+        "output": 0,
         "cache_creation": 0,
         "cache_read": 0,
-        "reasoning": 1.60,
+        "reasoning": 0,
     },
 }
 

--- a/src/reverse_api/pricing.py
+++ b/src/reverse_api/pricing.py
@@ -92,6 +92,28 @@ MODEL_PRICING = {
         "cache_read": 0.50,
         "reasoning": 25.00,
     },
+    # GPT models (for Copilot SDK - cost is $0 with GitHub subscription)
+    "gpt-5": {
+        "input": 2.00,
+        "output": 8.00,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "reasoning": 8.00,
+    },
+    "gpt-4.1": {
+        "input": 2.00,
+        "output": 8.00,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "reasoning": 8.00,
+    },
+    "gpt-4.1-mini": {
+        "input": 0.40,
+        "output": 1.60,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "reasoning": 1.60,
+    },
 }
 
 

--- a/src/reverse_api/tui.py
+++ b/src/reverse_api/tui.py
@@ -33,6 +33,13 @@ TOOL_ICONS = {
     "WebFetch": "wf",
     "Task": "tk",
     "AskUserQuestion": "??",
+    "browser_navigate": "br",
+    "browser_click": "br",
+    "browser_type": "br",
+    "browser_snapshot": "br",
+    "browser_tabs": "br",
+    "browser_lock": "br",
+    "browser_unlock": "br",
     "default": "> ",
 }
 
@@ -165,6 +172,17 @@ class ClaudeUI:
         elif tool_name == "WebFetch":
             url = tool_input.get("url", "")
             return f"[dim]{url[:60]}{'...' if len(url) > 60 else ''}[/dim]"
+        elif tool_name == "browser_navigate":
+            url = tool_input.get("url", "")
+            return f"[dim]{url[:50]}{'...' if len(url) > 50 else ''}[/dim]"
+        elif tool_name == "browser_click":
+            ref = tool_input.get("elementRef", "")
+            return f"[dim]ref={ref[:40]}{'...' if len(ref) > 40 else ''}[/dim]"
+        elif tool_name == "browser_type":
+            text = tool_input.get("text", "")[:30]
+            return f"[dim]'{text}{'...' if len(text) >= 30 else ''}'[/dim]"
+        elif tool_name == "browser_snapshot":
+            return "[dim]page structure[/dim]"
         return ""
 
     def _truncate_path(self, path: str, max_len: int = 60) -> str:

--- a/src/reverse_api/tui.py
+++ b/src/reverse_api/tui.py
@@ -113,20 +113,17 @@ class ClaudeUI:
                 if len(output_lines) > max_lines:
                     self.console.print(f"  [dim]│[/dim] [dim]... ({len(output_lines) - max_lines} more lines)[/dim]")
 
-    def thinking(self, text: str, max_length: int = 100) -> None:
+    def thinking(self, text: str, max_length: int = 500) -> None:
         """Display Claude's thinking/response text."""
         if not self.verbose:
             return
 
-        # Only show substantial thinking (skip short status updates)
-        if len(text) < 20:
+        if len(text) < 5:
             return
 
-        # Truncate and clean
-        display_text = text[:max_length].replace("\n", " ").strip()
-        if len(text) > max_length:
-            display_text += "..."
-
+        display_text = text.replace("\n", " ").strip()
+        if len(display_text) > max_length:
+            display_text = display_text[:max_length] + "..."
         self.console.print(f"  [dim].. {display_text}[/dim]")
 
     def progress(self, message: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -782,6 +782,23 @@ wheels = [
 ]
 
 [[package]]
+name = "github-copilot-sdk"
+version = "0.1.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/67/ebd002c14fe7d2640d0fff47a0b29fdb21ed239b597afa2d2c6f6cfebb0b/github_copilot_sdk-0.1.32-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d97bc39fbd4b51e0aea3405299da1e643838ddbf6bff284f688a2d8c20d82ff8", size = 58576987, upload-time = "2026-03-07T15:28:24.062Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/50/add440f61e19f5b7e6989c89c5cefcb14c23f06627621e7c3a15a1f75e5d/github_copilot_sdk-0.1.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8098592f34e7ee7decbcbb7615c7eb924471e65a3e4d0d93bc49b0d112f8ec51", size = 55328145, upload-time = "2026-03-07T15:28:28.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b8/c3ca0678b21d8a0dd8fe3aa8fad4b7ec5f22cbe9d5fb3a11f82df4f40578/github_copilot_sdk-0.1.32-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c20cae4bec3584ce007a65a363216a1f98a71428a3ca3b76622f9e556307eed2", size = 61456678, upload-time = "2026-03-07T15:28:32.646Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5c/bdfe177353f88d44da9600c3ec478e2b0df7a838901947b168e869ba5ad7/github_copilot_sdk-0.1.32-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0941fd445e97a9b13fb713086c4a8c09c20ec8c7ab854cf009bd7cc213488999", size = 59641536, upload-time = "2026-03-07T15:28:36.977Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d0/2f3a07c74ecd24587b8f7d26729738f73e63f3341bf4bdc9eb2bb73ddaaf/github_copilot_sdk-0.1.32-py3-none-win_amd64.whl", hash = "sha256:37a82ff0908e01512052b69df4aa498332fa5769999635425015ed43cd850622", size = 54077464, upload-time = "2026-03-07T15:28:41.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/76/292088d6ccf2daf8bcb8a94b22b4f16005a6772087896f1b43c4f0d5edaa/github_copilot_sdk-0.1.32-py3-none-win_arm64.whl", hash = "sha256:3199c99604e8d393b1d60905be80b84da44e70d16d30b92e2ae9b92814cdc4ae", size = 52083845, upload-time = "2026-03-07T15:28:45.092Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1934,6 +1951,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2185,6 +2214,9 @@ collector = [
     { name = "beautifulsoup4" },
     { name = "markdownify" },
 ]
+copilot = [
+    { name = "github-copilot-sdk" },
+]
 pricing = [
     { name = "litellm" },
 ]
@@ -2206,6 +2238,7 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.0" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = ">=0.1.0" },
     { name = "litellm", marker = "extra == 'pricing'", specifier = ">=1.0.0" },
     { name = "markdownify", marker = "extra == 'collector'", specifier = ">=0.12.0" },
     { name = "playwright", specifier = ">=1.40.0" },
@@ -2217,7 +2250,7 @@ requires-dist = [
     { name = "stagehand", marker = "extra == 'agent'" },
     { name = "watchdog", specifier = ">=3.0.0" },
 ]
-provides-extras = ["agent", "pricing", "collector"]
+provides-extras = ["agent", "pricing", "collector", "copilot"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub Copilot as a third SDK (`sdk=copilot`) with streaming analysis, MCP-powered auto mode, and better TUI visibility for tools and thinking. Fixes Python 3.11 f-string compatibility and minor warnings; exposes `copilot_model` (default `gpt-5`) and addresses #42.

- **New Features**
  - New `CopilotEngineer` and `CopilotAutoEngineer` using `github-copilot-sdk`; shared `ask_user_question` via `BaseEngineer._ask_user_interactive`.
  - Auto mode runs MCP Playwright via `npx -y rae-playwright-mcp@latest` with tool hooks and auto-approve permissions.
  - CLI/REPL: select `sdk=copilot`; edit “Copilot Model” (`copilot_model`, default `gpt-5`).
  - TUI shows `browser_*` tools with icons and concise input summaries; longer streaming “thinking” previews.
  - Stability: 600s timeout, thread-safe event signaling, guaranteed `CopilotClient.stop()`; token usage displayed; GPT models marked $0 for Copilot.

- **Bug Fixes**
  - Python 3.11 compatibility: replaced multi-line f-strings in prompts with variables.
  - Prefixed unused `_invocation` param and hardened event callbacks with `loop.call_soon_threadsafe`.

<sup>Written for commit 1002ee2e8b5dc8b7de0caac302a6ab684ddaa827. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully introduces a third SDK option (`sdk=copilot`) backed by the `github-copilot-sdk`, adding `CopilotEngineer`, `CopilotAutoEngineer`, shared interactive questioning via `BaseEngineer._ask_user_interactive`, MCP-Playwright integration for auto mode, and Python 3.11 f-string compatibility fixes.

The implementation is solid on critical paths — timeout handling (`asyncio.wait_for` with 600s protection), resource cleanup (guaranteed `client.stop()` in finally blocks), and thread-safe event signalling (`loop.call_soon_threadsafe`) are all properly implemented. However, three code-quality issues remain:

1. **Display logic bug in `tui.py`** (line 179–180): the truncation guard evaluates against the already-sliced string, producing a spurious `...` on exactly-30-character text.
2. **Inconsistent thread-safety in `on_event`** callbacks (lines 639–657 in `auto_engineer.py`, similar in `copilot_engineer.py`): only `done_event.set` is protected with `loop.call_soon_threadsafe`, while concurrent mutations to `accumulated_text`, UI calls, and `usage_metadata` are left unprotected.
3. **Tight coupling to private method** (`auto_engineer.py` line 632): `CopilotAutoEngineer` reaches into `ClaudeAutoEngineer._build_auto_prompt`, creating an implicit fragile dependency across sibling classes.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes — no security issues or functional breakage, but one display logic bug and two code-quality concerns should be addressed.
- The core functionality is well-implemented: timeout protection (600s via `asyncio.wait_for`), guaranteed resource cleanup (finally blocks with `client.stop()`), and thread-safe event signalling are all in place. However, three issues remain: (1) a confirmed display logic bug in `tui.py` causing spurious ellipsis on exactly-30-char strings, (2) inconsistent thread-safety wrappers in the `on_event` callback (only `done_event.set` uses `loop.call_soon_threadsafe`), and (3) fragile coupling to a private sibling method. These are code-quality concerns rather than immediate breakage, but they warrant attention.
- `src/reverse_api/tui.py` (truncation bug on line 179), `src/reverse_api/auto_engineer.py` (on_event thread-safety consistency and private method coupling), `src/reverse_api/copilot_engineer.py` (on_event thread-safety consistency).

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/reverse_api/auto_engineer.py`, line 73 ([link](https://github.com/kalil0321/reverse-api-engineer/blob/1e8a16d509b5d943d297389df987184c264a6fbf/src/reverse_api/auto_engineer.py#L73)) 

   **Couplage fragile avec une méthode privée de `ClaudeAutoEngineer`**

   `ClaudeAutoEngineer._build_auto_prompt(eng)` est appelée ici en mode "méthode non liée" (*unbound method*) sur `eng`, qui est une instance de `CopilotEngineer` — une classe qui n'hérite pas de `ClaudeAutoEngineer`. Bien que cela fonctionne actuellement car `_build_auto_prompt` n'utilise que des attributs définis dans `BaseEngineer`, ce couplage est fragile :

   - Si `_build_auto_prompt` est modifiée pour utiliser des attributs spécifiques à `ClaudeAutoEngineer` ou `ClaudeEngineer`, le code se cassera silencieusement à l'exécution (et non à la compilation).
   - Appeler une méthode privée (`_build_auto_prompt`) d'une classe sur une instance d'une autre classe est une violation des conventions d'encapsulation.

   La solution propre serait de déplacer `_build_auto_prompt` dans `BaseEngineer` (ou une classe `AutoEngineerMixin`), afin que `CopilotEngineer` puisse l'appeler directement via `eng._build_auto_prompt()` sans dépendre d'une implémentation externe.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/reverse_api/auto_engineer.py
   Line: 73

   Comment:
   **Couplage fragile avec une méthode privée de `ClaudeAutoEngineer`**

   `ClaudeAutoEngineer._build_auto_prompt(eng)` est appelée ici en mode "méthode non liée" (*unbound method*) sur `eng`, qui est une instance de `CopilotEngineer` — une classe qui n'hérite pas de `ClaudeAutoEngineer`. Bien que cela fonctionne actuellement car `_build_auto_prompt` n'utilise que des attributs définis dans `BaseEngineer`, ce couplage est fragile :

   - Si `_build_auto_prompt` est modifiée pour utiliser des attributs spécifiques à `ClaudeAutoEngineer` ou `ClaudeEngineer`, le code se cassera silencieusement à l'exécution (et non à la compilation).
   - Appeler une méthode privée (`_build_auto_prompt`) d'une classe sur une instance d'une autre classe est une violation des conventions d'encapsulation.

   La solution propre serait de déplacer `_build_auto_prompt` dans `BaseEngineer` (ou une classe `AutoEngineerMixin`), afin que `CopilotEngineer` puisse l'appeler directement via `eng._build_auto_prompt()` sans dépendre d'une implémentation externe.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/reverse_api/pricing.py`, line 865-885 ([link](https://github.com/kalil0321/reverse-api-engineer/blob/cd89a2c924f32b43904ad09a5c5c412ab710293c/src/reverse_api/pricing.py#L865-L885)) 

   **GPT model prices set to $0 may mislead non-Copilot runs**

   `gpt-5`, `gpt-4.1`, and `gpt-4.1-mini` are real OpenAI models with non-zero API costs. By registering them at `$0` in the shared `MODEL_PRICING` table, any code path that looks up cost for these model names — including the existing `litellm`-backed pricing path (`pricing` extra) — will silently report `$0` even when the user is calling the OpenAI API directly (not through a Copilot subscription).

   The Copilot code paths already hardcode `estimated_cost_usd = 0.0` directly, so the pricing table entries are not needed for correctness. Consider either removing these entries from the pricing table entirely, or scoping the `$0` override to a Copilot-specific look-up so normal OpenAI usage isn't misreported.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/reverse_api/pricing.py
   Line: 865-885

   Comment:
   **GPT model prices set to $0 may mislead non-Copilot runs**

   `gpt-5`, `gpt-4.1`, and `gpt-4.1-mini` are real OpenAI models with non-zero API costs. By registering them at `$0` in the shared `MODEL_PRICING` table, any code path that looks up cost for these model names — including the existing `litellm`-backed pricing path (`pricing` extra) — will silently report `$0` even when the user is calling the OpenAI API directly (not through a Copilot subscription).

   The Copilot code paths already hardcode `estimated_cost_usd = 0.0` directly, so the pricing table entries are not needed for correctness. Consider either removing these entries from the pricing table entirely, or scoping the `$0` override to a Copilot-specific look-up so normal OpenAI usage isn't misreported.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 1002ee2</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e07b4d33-1c4e-453f-bed1-db59da843368))

<!-- /greptile_comment -->