### PR TITLE
feat(cli): add list subcommand for script/run discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-10
+
+### Added
+- **`list` CLI subcommand**: Non-interactive command to list generated scripts and runs
+  - Rich table output (compact and full modes) and JSON output (`--json`)
+  - Filter by mode (`--mode`), model (`--model`), prompt search (`--search`), and limit (`--limit`)
+  - Shows script directory paths, file counts, and local path detection
+
 ## [0.3.3] - 2026-03-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reverse-api-engineer"
-version = "0.3.3"
+version = "0.4.0"
 description = "A tool to capture browser traffic for API reverse engineering"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import re
 from pathlib import Path
 
@@ -36,6 +37,7 @@ from .utils import (
     generate_folder_name,
     generate_run_id,
     get_actions_path,
+    get_base_output_dir,
     get_config_path,
     get_har_dir,
     get_history_path,
@@ -1728,6 +1730,126 @@ def run_engineer(
             paths={"script_path": result.get("script_path")},
         )
     return result
+
+
+def _get_run_details(run: dict) -> dict:
+    """Enrich a history entry with filesystem info."""
+    run_id = run.get("run_id", "")
+    output_dir = config_manager.get("output_dir")
+    base_dir = get_base_output_dir(output_dir)
+    script_dir = base_dir / "scripts" / run_id
+
+    files = []
+    if script_dir.exists():
+        files = sorted(f.name for f in script_dir.iterdir() if f.is_file())
+
+    # Scan ./scripts/ subdirectories to find local copy
+    local_path = None
+    local_scripts = Path.cwd() / "scripts"
+    if local_scripts.exists() and files:
+        files_set = set(files)
+        for subdir in local_scripts.iterdir():
+            if subdir.is_dir():
+                local_files = {f.name for f in subdir.iterdir() if f.is_file()}
+                if local_files and local_files == files_set:
+                    local_path = f"./scripts/{subdir.name}/"
+                    break
+
+    usage = run.get("usage", {})
+    cost = usage.get("total_cost", usage.get("cost"))
+
+    return {
+        "run_id": run_id,
+        "prompt": run.get("prompt", ""),
+        "timestamp": run.get("timestamp", ""),
+        "model": run.get("model", ""),
+        "mode": run.get("mode", ""),
+        "sdk": run.get("sdk", ""),
+        "cost": cost,
+        "script_dir": str(script_dir),
+        "files": files,
+        "file_count": len(files),
+        "local_path": local_path,
+    }
+
+
+@main.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as flat JSON array.")
+@click.option("--full", is_flag=True, help="Show all columns (default: compact view).")
+@click.option("--limit", "-n", type=int, default=None, help="Limit number of results.")
+@click.option("--mode", "-m", type=str, default=None, help="Filter by mode (auto/manual/agent/engineer/collector).")
+@click.option("--model", type=str, default=None, help="Filter by model name.")
+@click.option("--search", "-s", type=str, default=None, help="Case-insensitive substring match on prompt.")
+def list_runs(as_json, full, limit, mode, model, search):
+    """List generated scripts and runs with optional filters."""
+    from rich.table import Table
+
+    runs = list(session_manager.history)
+
+    if mode:
+        runs = [r for r in runs if r.get("mode", "") == mode]
+    if model:
+        runs = [r for r in runs if model.lower() in (r.get("model") or "").lower()]
+    if search:
+        runs = [r for r in runs if search.lower() in (r.get("prompt") or "").lower()]
+
+    if not runs:
+        if not session_manager.history:
+            console.print("No runs found.", style="dim")
+        else:
+            console.print("No matching runs found.")
+        return
+
+    if limit is not None:
+        runs = runs[:limit]
+
+    results = [_get_run_details(r) for r in runs]
+
+    if as_json:
+        click.echo(json.dumps(results, indent=2))
+        return
+
+    if full:
+        table = Table(show_lines=False)
+        table.add_column("run_id", style="cyan")
+        table.add_column("prompt", max_width=40)
+        table.add_column("timestamp")
+        table.add_column("model")
+        table.add_column("mode")
+        table.add_column("sdk")
+        table.add_column("cost", justify="right")
+        table.add_column("script_dir")
+        table.add_column("files", justify="right")
+        for r in results:
+            prompt = r["prompt"][:40] + ("..." if len(r["prompt"]) > 40 else "")
+            cost_str = f"${r['cost']:.2f}" if r["cost"] is not None else ""
+            table.add_row(
+                r["run_id"],
+                prompt,
+                r["timestamp"],
+                r["model"] or "",
+                r["mode"] or "",
+                r["sdk"] or "",
+                cost_str,
+                r["script_dir"],
+                str(r["file_count"]),
+            )
+    else:
+        table = Table(show_lines=False)
+        table.add_column("run_id", style="cyan")
+        table.add_column("prompt", max_width=40)
+        table.add_column("timestamp")
+        table.add_column("script_dir")
+        for r in results:
+            prompt = r["prompt"][:40] + ("..." if len(r["prompt"]) > 40 else "")
+            table.add_row(
+                r["run_id"],
+                prompt,
+                r["timestamp"],
+                r["script_dir"],
+            )
+
+    console.print(table)
 
 
 @main.command("install-host")

--- a/uv.lock
+++ b/uv.lock
@@ -2189,7 +2189,7 @@ wheels = [
 
 [[package]]
 name = "reverse-api-engineer"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Adds `reverse-api-engineer list` non-interactive CLI subcommand
- Rich table output (compact/full) and JSON output (`--json`)
- Filters: `--mode`, `--model`, `--search`, `--limit`
- Enriches runs with script directory paths, file counts, and local path detection
- Bumps version to v0.4.0

## Test plan
- [x] `reverse-api-engineer list` — Rich table renders with all runs
- [x] `reverse-api-engineer list --json` — valid JSON array
- [x] `reverse-api-engineer list --search "hn" --limit 2` — filtered correctly
- [x] `reverse-api-engineer list --help` — all options documented
- [x] `ruff check` — no new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `reverse-api-engineer list` to quickly discover generated scripts and past runs. Supports compact/full table views and `--json`, with filters and filesystem details.

- **New Features**
  - Non-interactive `list` subcommand with rich table (compact/full) and `--json`.
  - Filters: `--mode`, `--model`, `--search`, `--limit`.
  - Adds script directory path, file list/count, and local copy detection.
  - Bumps `reverse-api-engineer` to `0.4.0`.

<sup>Written for commit 3a26e3e61cbac4b18b93c5b9a552be4369115795. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `reverse-api-engineer list` subcommand that renders run history as a Rich table (compact/full) or JSON, with filters for mode, model, prompt search, and row limit, and bumps the version to v0.4.0.

- **Path-traversal bypass in `_get_run_details`**: `run_id` is taken directly from the history JSON and used to build a filesystem path without the regex, length, or `is_relative_to` guards that `get_scripts_dir` / `get_har_dir` / `get_docs_dir` all apply. A corrupted history entry could silently traverse outside the expected directory.
- **Unhandled `OSError` in `iterdir()` calls**: All three `iterdir()` calls (`script_dir`, `local_scripts`, and each `subdir`) can raise `PermissionError` or `OSError`, which would crash the entire `list` command via an unhandled exception inside a list comprehension.
- **`local_path` not shown in table output**: The field is computed and correctly included in `--json` output, but neither the compact nor `--full` table renders it, despite the PR description listing "local path detection" as a visible feature.
- `uv.lock` version (previously `0.3.2`) was out of sync with `pyproject.toml` (`0.3.3`); both are now correctly aligned at `0.4.0`.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with low risk, but the path-traversal bypass should be addressed before shipping to users who may have untrusted history files.
- The new command is additive and read-only, so there is no data-loss risk. However, `_get_run_details` skips the `run_id` validation that every other path-building utility in the codebase enforces, which is a correctness/security regression. The missing `OSError` guards could also cause the command to crash unexpectedly for legitimate users.
- src/reverse_api/cli.py — specifically the `_get_run_details` helper (lines 1735–1773)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/cli.py | Adds `_get_run_details` helper and `list` subcommand. The helper bypasses the existing `run_id` path-traversal validation used everywhere else in the codebase, and all three `iterdir()` calls lack `OSError` handling. The computed `local_path` field is also missing from the table output despite being documented as a feature. |
| pyproject.toml | Version bumped from 0.3.3 to 0.4.0, consistent with the new `list` subcommand feature addition. |
| CHANGELOG.md | New [0.4.0] entry added documenting the `list` CLI subcommand and its options. No issues. |
| uv.lock | Lock file updated to reflect version 0.4.0; also resolves a pre-existing discrepancy where the lock file had 0.3.2 while pyproject.toml said 0.3.3. |

</details>

<sub>Last reviewed commit: 3a26e3e</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->