### PR TITLE
fix: keep engineer edits in the existing client language

### DIFF
--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -15,6 +15,12 @@ from .utils import generate_folder_name, get_docs_dir, get_scripts_dir
 class BaseEngineer(ABC):
     """Abstract base class for API reverse engineering implementations."""
 
+    _OUTPUT_LANGUAGE_EXTENSIONS = {
+        "python": ".py",
+        "javascript": ".js",
+        "typescript": ".ts",
+    }
+
     def __init__(
         self,
         run_id: str,
@@ -49,7 +55,8 @@ class BaseEngineer(ABC):
         self.enable_sync = enable_sync
         self.sdk = sdk
         self.is_fresh = is_fresh
-        self.output_language = output_language
+        self.output_language = self._resolve_output_language(output_language)
+        self.existing_client_path = self._get_existing_client_path()
         self.sync_watcher: FileSyncWatcher | None = None
         self.local_scripts_dir: Path | None = None
 
@@ -223,11 +230,63 @@ class BaseEngineer(ABC):
 
     def _get_output_extension(self) -> str:
         """Return file extension based on output language."""
+        return self._OUTPUT_LANGUAGE_EXTENSIONS.get(self.output_language, ".py")
+
+    def _get_existing_client_candidates(self) -> dict[str, Path]:
+        """Return existing API client files keyed by language."""
+        if self.output_mode == "docs":
+            return {}
+
+        candidates: dict[str, Path] = {}
+        for language, extension in self._OUTPUT_LANGUAGE_EXTENSIONS.items():
+            client_path = self.scripts_dir / f"api_client{extension}"
+            if client_path.exists():
+                candidates[language] = client_path
+        return candidates
+
+    def _resolve_output_language(self, requested_language: str) -> str:
+        """Keep iterative edits in the same language as the existing client."""
+        if self.output_mode == "docs" or self.is_fresh:
+            return requested_language
+
+        existing_clients = self._get_existing_client_candidates()
+        if not existing_clients:
+            return requested_language
+
+        if requested_language in existing_clients:
+            return requested_language
+
+        return max(
+            existing_clients.items(),
+            key=lambda item: item[1].stat().st_mtime_ns,
+        )[0]
+
+    def _get_existing_client_path(self) -> Path | None:
+        """Return the current client path when iterating on an existing run."""
+        return self._get_existing_client_candidates().get(self.output_language)
+
+    def _get_language_name(self) -> str:
+        """Return a human-readable language name."""
         return {
-            "python": ".py",
-            "javascript": ".js",
-            "typescript": ".ts",
-        }.get(self.output_language, ".py")
+            "python": "Python",
+            "javascript": "JavaScript",
+            "typescript": "TypeScript",
+        }.get(self.output_language, "Python")
+
+    def _get_existing_client_guidance(self) -> str:
+        """Return prompt guidance for iterative edits on an existing client."""
+        if self.output_mode == "docs" or self.is_fresh or not self.existing_client_path:
+            return ""
+
+        language_name = self._get_language_name()
+        return f"""
+There is already an existing {language_name} client for this run:
+<existing_client>
+{self.existing_client_path}
+</existing_client>
+
+**IMPORTANT: This is an iterative edit. Update that file in place and keep the implementation in {language_name} unless the user explicitly asks for a fresh rewrite.**
+"""
 
     def _get_client_filename(self) -> str:
         """Return the output filename based on mode."""
@@ -425,11 +484,7 @@ Your OpenAPI spec should be production-ready and suitable for:
             mode_description = "generate an OpenAPI 3.0 specification documenting"
             task_description = "OpenAPI documentation"
         else:
-            language_name = {
-                "python": "Python",
-                "javascript": "JavaScript",
-                "typescript": "TypeScript",
-            }.get(self.output_language, "Python")
+            language_name = self._get_language_name()
             mode_description = f"reverse engineer API calls and generate production-ready {language_name} code that replicates"
             task_description = f"{language_name} API client"
 
@@ -464,6 +519,7 @@ Here is the output directory where you should save your generated files:
 <output_dir>
 {self.scripts_dir}
 </output_dir>
+{self._get_existing_client_guidance()}
 
 **IMPORTANT: You have access to the AskUserQuestion tool to ask clarifying questions during your analysis.**
 Use this tool when you need to clarify functional requirements, prioritize features, choose between implementation approaches, or gather any other information that would help you generate better {task_description}.

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -58,6 +58,50 @@ class TestBaseEngineerInit:
                 mock_docs.assert_called_once()
                 assert engineer.output_mode == "docs"
 
+    def test_existing_client_language_preserved_for_iterative_runs(self, tmp_path):
+        """Existing client language overrides the configured output language."""
+        har_path = tmp_path / "test.har"
+        har_path.touch()
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        client_path = scripts_dir / "api_client.ts"
+        client_path.write_text("export {};\n")
+
+        with patch("reverse_api.base_engineer.get_scripts_dir", return_value=scripts_dir):
+            with patch("reverse_api.base_engineer.MessageStore"):
+                engineer = ConcreteEngineer(
+                    run_id="test123",
+                    har_path=har_path,
+                    prompt="test prompt",
+                    output_language="python",
+                    output_dir=str(tmp_path),
+                )
+
+        assert engineer.output_language == "typescript"
+        assert engineer.existing_client_path == client_path
+
+    def test_fresh_runs_can_switch_output_language(self, tmp_path):
+        """Fresh runs ignore existing client language and honor the requested one."""
+        har_path = tmp_path / "test.har"
+        har_path.touch()
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "api_client.ts").write_text("export {};\n")
+
+        with patch("reverse_api.base_engineer.get_scripts_dir", return_value=scripts_dir):
+            with patch("reverse_api.base_engineer.MessageStore"):
+                engineer = ConcreteEngineer(
+                    run_id="test123",
+                    har_path=har_path,
+                    prompt="test prompt",
+                    output_language="python",
+                    is_fresh=True,
+                    output_dir=str(tmp_path),
+                )
+
+        assert engineer.output_language == "python"
+        assert engineer.existing_client_path is None
+
 
 class TestBaseEngineerHelpers:
     """Test helper methods."""
@@ -198,6 +242,32 @@ class TestBaseEngineerBuildPrompt:
         prompt = eng._build_analysis_prompt()
         assert "Tag-Based Workflows" in prompt
         assert eng.run_id in prompt
+
+    def test_prompt_includes_existing_client_guidance(self, tmp_path):
+        """Prompt tells the agent to keep editing the existing client language."""
+        har_path = tmp_path / "test.har"
+        har_path.touch()
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        client_path = scripts_dir / "api_client.js"
+        client_path.write_text("export {};\n")
+
+        with patch("reverse_api.base_engineer.get_scripts_dir", return_value=scripts_dir):
+            with patch("reverse_api.base_engineer.get_docs_dir", return_value=tmp_path / "docs"):
+                with patch("reverse_api.base_engineer.MessageStore") as mock_ms:
+                    mock_ms.return_value.messages_path = tmp_path / "messages" / "test.jsonl"
+                    eng = ConcreteEngineer(
+                        run_id="test123",
+                        har_path=har_path,
+                        prompt="test prompt",
+                        output_language="python",
+                        output_dir=str(tmp_path),
+                    )
+
+        prompt = eng._build_analysis_prompt()
+        assert str(client_path) in prompt
+        assert "iterative edit" in prompt
+        assert "JavaScript" in prompt
 
 
 class TestBaseEngineerSync:


### PR DESCRIPTION
## Summary
- preserve the existing `api_client` language for iterative engineer runs
- keep `--fresh` as the escape hatch for intentionally switching languages
- add prompt guidance and regression coverage for existing-client detection

## Testing
- `uv run pytest tests/test_base_engineer.py -q`

Closes #34

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep engineer edits in the existing API client language and only switch languages on fresh runs. Adds prompt guidance and tests to prevent accidental language flips across iterations.

- **Bug Fixes**
  - Detect existing `api_client` files (`.py`, `.js`, `.ts`) and pin iterative runs to that language; if multiple exist, pick the most recently updated.
  - Honor the requested language only for fresh runs (`--fresh`) or in docs mode.
  - Inject clear guidance into the analysis prompt with the existing client path and language; added tests for language resolution and prompt content.

<sup>Written for commit ccfd2a6d954883e19e486b97b6c9c22e9ee0b171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where re-running the engineer on an existing run with a different default `output_language` would silently switch the generated file to a new language, discarding the previous client's language choice. The fix detects any existing `api_client.*` files in the run's scripts directory at construction time and locks `output_language` to the detected language, with `--fresh` as the explicit escape hatch.

**Key changes:**
- New class-level `_OUTPUT_LANGUAGE_EXTENSIONS` dict centralises extension-to-language mappings, replacing three separate inline dicts.
- `_resolve_output_language` selects the most-recently-modified existing client's language when the requested language isn't already present; safe no-ops for docs mode and fresh runs.
- `_get_existing_client_guidance` injects a short, targeted prompt reminding the agent to edit the existing file in place rather than creating a new one.
- Two new init tests and one prompt-content test cover the happy path, the `--fresh` bypass, and the guidance injection.

**Minor concerns noted:**
- `_get_existing_client_candidates()` is traversed twice during `__init__` (once via `_resolve_output_language`, once via `_get_existing_client_path`); the result could be computed once and reused.
- One test unnecessarily patches `get_docs_dir` when only `client` mode is exercised.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the new logic is well-scoped, initialization order is correct, and the core behavior is covered by tests.
- All attribute dependencies (`output_mode`, `is_fresh`, `scripts_dir`) are set before the new methods are called in `__init__`. The three added tests cover the main new code paths. The only concerns are a minor redundant filesystem scan and a trivial unnecessary mock in one test — neither affects correctness.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/base_engineer.py | Adds language-preservation logic for iterative runs: new `_resolve_output_language`, `_get_existing_client_candidates`, `_get_existing_client_path`, `_get_language_name`, and `_get_existing_client_guidance` methods. `_get_existing_client_candidates()` is called twice during `__init__` (once inside `_resolve_output_language`, again inside `_get_existing_client_path`), causing a redundant filesystem scan. |
| tests/test_base_engineer.py | Adds three new tests covering language preservation for iterative runs, fresh-run language override, and prompt guidance injection. One test patches `get_docs_dir` unnecessarily (the engineer under test uses the default `client` mode, not `docs` mode). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/reverse_api/base_engineer.py
Line: 58-59

Comment:
**Redundant filesystem scan on init**

`_get_existing_client_candidates()` is called twice during construction — once inside `_resolve_output_language` (line 58) and again inside `_get_existing_client_path` (line 59). Each call walks `self.scripts_dir` looking for all three possible client files.

Since `_resolve_output_language` already computes the candidates dict, the result could be reused to derive `existing_client_path` without a second scan:

```suggestion
        candidates = self._get_existing_client_candidates()
        self.output_language = self._resolve_output_language(output_language, candidates)
        self.existing_client_path = candidates.get(self.output_language)
```

…with `_resolve_output_language` updated to accept the pre-computed `candidates` dict as a second argument. This keeps the logic identical while halving the I/O.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_base_engineer.py
Line: 271-275

Comment:
**Unnecessary `get_docs_dir` patch**

The engineer under test uses the default `output_mode="client"`, so `get_docs_dir` is never called — only `get_scripts_dir` is. The patch is harmless but adds noise and could mislead future readers into thinking docs mode is exercised here.

```suggestion
        with patch("reverse_api.base_engineer.get_scripts_dir", return_value=scripts_dir):
            with patch("reverse_api.base_engineer.MessageStore") as mock_ms:
                mock_ms.return_value.messages_path = tmp_path / "messages" / "test.jsonl"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ccfd2a6</sub>

<!-- /greptile_comment -->