### PR TITLE
feat: add `run` command to execute generated scripts

### DIFF
--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2162,7 +2162,7 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     python_path = str(venv_python)
 
     # Execute (with retry on missing imports)
-    console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]")
+    console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]\n  [dim]{script}[/dim]")
     result = subprocess.run(
         [python_path, str(script), *script_args],
         capture_output=True, text=True,

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2165,17 +2165,19 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
 
     python_path = str(venv_python)
 
-    # Execute with real-time output
+    # Execute with real-time stdout, capture stderr for import error detection
     cmd = [python_path, str(script), *script_args]
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True)
 
-    # On failure, check if it's a missing import and offer to install
+    # Print stderr so the user sees it, then check for missing imports
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+
     if result.returncode != 0:
-        probe = subprocess.run(cmd, capture_output=True, text=True)
-        if "ModuleNotFoundError: No module named" in (probe.stderr or ""):
+        if "ModuleNotFoundError: No module named" in (result.stderr or ""):
             import re as _re
 
-            match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", probe.stderr)
+            match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", result.stderr)
             if match:
                 missing = match.group(1)
                 console.print(f"[yellow]Missing dependency: {missing}[/yellow]")

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2162,7 +2162,9 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     python_path = str(venv_python)
 
     # Execute (with retry on missing imports)
-    console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]\n  [dim]{script}[/dim]")
+    prompt_preview = (run.get("prompt") or "")[:80]
+    console.print(f"run {run_id} | {prompt_preview}", style="dim")
+    console.print(f"  {script}", style="dim")
     result = subprocess.run(
         [python_path, str(script), *script_args],
         capture_output=True, text=True,

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2097,6 +2097,9 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     # Discover scripts (prefer stored path from run metadata, fall back to output_dir)
     scripts = discover_scripts(run_id, output_dir, run_metadata=run)
 
+    prompt_preview = (run.get("prompt") or "")[:80]
+    ts = (run.get("timestamp") or "")[:19]
+    console.print(f"{run_id}  {ts}  {prompt_preview}", style="dim")
     if scripts:
         console.print(f"{scripts[0].parent}", style="dim")
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -35,6 +35,7 @@ from .tui import (
 )
 from .utils import (
     check_for_updates,
+    discover_scripts,
     generate_folder_name,
     generate_run_id,
     get_actions_path,
@@ -48,6 +49,7 @@ from .utils import (
     parse_codegen_tag,
     parse_engineer_prompt,
     parse_record_only_tag,
+    resolve_run,
 )
 
 setproctitle.setproctitle("reverse-api-engineer")
@@ -2058,6 +2060,109 @@ def show_run(run_id, as_json):
 
     console.print(f"\nRun {rid}")
     console.print(table)
+
+
+@main.command("run")
+@click.argument("identifier")
+@click.argument("script_args", nargs=-1, type=click.UNPROCESSED)
+@click.option("--file", "-f", "file_name", default=None, help="Script filename to run (e.g. api_client.py).")
+@click.option("--ls", "list_scripts", is_flag=True, help="List available scripts without executing.")
+@click.pass_context
+def run_script(ctx, identifier, script_args, file_name, list_scripts):
+    """Run a generated script from a previous run.
+
+    IDENTIFIER is a run ID or search term to match against prompts.
+    Any extra arguments after the identifier are passed to the script.
+
+    Examples:
+
+        reverse-api-engineer run a450e520ca30
+
+        reverse-api-engineer run ashby --ls
+
+        reverse-api-engineer run ashby --file api_client.py
+
+        reverse-api-engineer run ashby -- --org acme --limit 10
+    """
+    import subprocess
+    import sys
+
+    from rich.table import Table
+
+    # Resolve which run
+    run = resolve_run(identifier, session_manager)
+    run_id = run["run_id"]
+    output_dir = config_manager.get("output_dir")
+
+    # Discover scripts
+    scripts = discover_scripts(run_id, output_dir)
+
+    if not scripts:
+        console.print(f"[red]No Python scripts found for run {run_id}[/red]")
+        prompt_preview = (run.get("prompt") or "")[:60]
+        console.print(f"  prompt: {prompt_preview}", style="dim")
+        raise SystemExit(1)
+
+    # --ls: just list and exit
+    if list_scripts:
+        table = Table(title=f"Scripts in run {run_id}")
+        table.add_column("File", style="cyan")
+        table.add_column("Size", justify="right")
+        table.add_column("Modified")
+        for s in scripts:
+            stat = s.stat()
+            size = f"{stat.st_size:,} B"
+            from datetime import datetime
+
+            modified = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+            table.add_row(s.name, size, modified)
+        console.print(table)
+        return
+
+    # Select script
+    if file_name:
+        # Exact filename match
+        matching = [s for s in scripts if s.name == file_name]
+        if not matching:
+            available = ", ".join(s.name for s in scripts)
+            raise click.ClickException(f"'{file_name}' not found. Available: {available}")
+        script = matching[0]
+    elif len(scripts) == 1:
+        script = scripts[0]
+    else:
+        # Interactive picker
+        choices = [questionary.Choice(title=s.name, value=s) for s in scripts]
+        script = questionary.select(
+            "Select script to run:",
+            choices=choices,
+        ).ask()
+        if script is None:
+            raise click.Abort()
+
+    # Venv / dependency management
+    scripts_dir = script.parent
+    requirements = scripts_dir / "requirements.txt"
+    venv_dir = scripts_dir / ".venv"
+
+    if requirements.exists():
+        python_path = venv_dir / "bin" / "python"
+        if not venv_dir.exists():
+            console.print("Installing dependencies...", style="dim")
+            subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+            pip_path = venv_dir / "bin" / "pip"
+            subprocess.run(
+                [str(pip_path), "install", "-q", "-r", str(requirements)],
+                check=True,
+            )
+            console.print("Dependencies installed.", style="dim")
+        python_path = str(python_path)
+    else:
+        python_path = sys.executable
+
+    # Execute
+    console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]")
+    result = subprocess.run([python_path, str(script), *script_args])
+    raise SystemExit(result.returncode)
 
 
 @main.command("install-host")

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2097,11 +2097,8 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     # Discover scripts (prefer stored path from run metadata, fall back to output_dir)
     scripts = discover_scripts(run_id, output_dir, run_metadata=run)
 
-    # Show run info after resolution
-    prompt_preview = (run.get("prompt") or "")[:80]
-    console.print(f"run {run_id} | {prompt_preview}", style="dim")
     if scripts:
-        console.print(f"  {scripts[0].parent}", style="dim")
+        console.print(f"{scripts[0].parent}", style="dim")
 
     if not scripts:
         console.print(f"[red]No Python scripts found for run {run_id}[/red]")

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2160,9 +2160,52 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     else:
         python_path = sys.executable
 
-    # Execute
+    # Execute (with retry on missing imports)
     console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]")
-    result = subprocess.run([python_path, str(script), *script_args])
+    result = subprocess.run(
+        [python_path, str(script), *script_args],
+        capture_output=True, text=True,
+    )
+
+    if result.returncode != 0 and "ModuleNotFoundError: No module named" in (result.stderr or ""):
+        # Extract module name from "No module named 'requests'"
+        import re as _re
+
+        match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", result.stderr)
+        if match:
+            missing = match.group(1)
+            console.print(f"[yellow]Missing dependency: {missing}[/yellow]")
+
+            install = questionary.confirm(
+                f"Install '{missing}' and retry?", default=True
+            ).ask()
+            if install:
+                # Ensure venv exists
+                venv_bin = "Scripts" if sys.platform == "win32" else "bin"
+                if not venv_dir.exists():
+                    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+                pip_path = venv_dir / venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
+                python_path = str(venv_dir / venv_bin / ("python.exe" if sys.platform == "win32" else "python"))
+
+                # Install the original requirements.txt too if it exists
+                if requirements.exists():
+                    subprocess.run([str(pip_path), "install", "-q", "-r", str(requirements)], check=True)
+                subprocess.run([str(pip_path), "install", "-q", missing], check=True)
+                console.print(f"Installed [green]{missing}[/green]. Retrying...")
+
+                result = subprocess.run([python_path, str(script), *script_args])
+                raise SystemExit(result.returncode)
+
+        # If we couldn't parse or user declined, show the original error
+        sys.stderr.write(result.stderr)
+        sys.stdout.write(result.stdout)
+        raise SystemExit(result.returncode)
+
+    # Normal exit — print captured output
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
     raise SystemExit(result.returncode)
 
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2179,7 +2179,7 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
 
             match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", result.stderr)
             if match:
-                missing = match.group(1)
+                missing = match.group(1).split(".")[0]
                 console.print(f"[yellow]Missing dependency: {missing}[/yellow]")
 
                 install = questionary.confirm(

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2105,8 +2105,6 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
 
     if not scripts:
         console.print(f"[red]No Python scripts found for run {run_id}[/red]")
-        prompt_preview = (run.get("prompt") or "")[:60]
-        console.print(f"  prompt: {prompt_preview}", style="dim")
         raise SystemExit(1)
 
     # --ls: just list and exit
@@ -2167,37 +2165,30 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
 
     python_path = str(venv_python)
 
-    # Execute (with retry on missing imports)
-    result = subprocess.run(
-        [python_path, str(script), *script_args],
-        capture_output=True, text=True,
-    )
+    # Execute with real-time output
+    cmd = [python_path, str(script), *script_args]
+    result = subprocess.run(cmd)
 
-    if result.returncode != 0 and "ModuleNotFoundError: No module named" in (result.stderr or ""):
-        import re as _re
+    # On failure, check if it's a missing import and offer to install
+    if result.returncode != 0:
+        probe = subprocess.run(cmd, capture_output=True, text=True)
+        if "ModuleNotFoundError: No module named" in (probe.stderr or ""):
+            import re as _re
 
-        match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", result.stderr)
-        if match:
-            missing = match.group(1)
-            console.print(f"[yellow]Missing dependency: {missing}[/yellow]")
+            match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", probe.stderr)
+            if match:
+                missing = match.group(1)
+                console.print(f"[yellow]Missing dependency: {missing}[/yellow]")
 
-            install = questionary.confirm(
-                f"Install '{missing}' and retry?", default=True
-            ).ask()
-            if install:
-                subprocess.run([str(venv_pip), "install", "-q", missing], check=True)
-                console.print(f"Installed [green]{missing}[/green]. Retrying...")
-                result = subprocess.run([python_path, str(script), *script_args])
-                raise SystemExit(result.returncode)
+                install = questionary.confirm(
+                    f"Install '{missing}' and retry?", default=True
+                ).ask()
+                if install:
+                    subprocess.run([str(venv_pip), "install", "-q", missing], check=True)
+                    console.print(f"Installed [green]{missing}[/green]. Retrying...")
+                    result = subprocess.run(cmd)
+                    raise SystemExit(result.returncode)
 
-        sys.stderr.write(result.stderr)
-        sys.stdout.write(result.stdout)
-        raise SystemExit(result.returncode)
-
-    if result.stdout:
-        sys.stdout.write(result.stdout)
-    if result.stderr:
-        sys.stderr.write(result.stderr)
     raise SystemExit(result.returncode)
 
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2139,26 +2139,27 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
         if script is None:
             raise click.Abort()
 
-    # Venv / dependency management
+    # Shared venv at ~/.reverse-api/runs/.venv (with requests pre-installed)
+    from .utils import get_base_output_dir as _get_base
+
+    venv_dir = _get_base(output_dir) / ".venv"
+    venv_bin = "Scripts" if sys.platform == "win32" else "bin"
+    venv_python = venv_dir / venv_bin / ("python.exe" if sys.platform == "win32" else "python")
+    venv_pip = venv_dir / venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
+
+    if not venv_dir.exists():
+        console.print("Setting up shared venv...", style="dim")
+        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+        subprocess.run([str(venv_pip), "install", "-q", "requests"], check=True)
+        console.print("Shared venv ready.", style="dim")
+
+    # Install per-run requirements.txt if present
     scripts_dir = script.parent
     requirements = scripts_dir / "requirements.txt"
-    venv_dir = scripts_dir / ".venv"
-
     if requirements.exists():
-        venv_bin = "Scripts" if sys.platform == "win32" else "bin"
-        python_path = venv_dir / venv_bin / ("python.exe" if sys.platform == "win32" else "python")
-        if not venv_dir.exists():
-            console.print("Installing dependencies...", style="dim")
-            subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
-            pip_path = venv_dir / venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
-            subprocess.run(
-                [str(pip_path), "install", "-q", "-r", str(requirements)],
-                check=True,
-            )
-            console.print("Dependencies installed.", style="dim")
-        python_path = str(python_path)
-    else:
-        python_path = sys.executable
+        subprocess.run([str(venv_pip), "install", "-q", "-r", str(requirements)], check=True)
+
+    python_path = str(venv_python)
 
     # Execute (with retry on missing imports)
     console.print(f"Running [cyan]{script.name}[/cyan] from run [dim]{run_id}[/dim]")
@@ -2168,7 +2169,6 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     )
 
     if result.returncode != 0 and "ModuleNotFoundError: No module named" in (result.stderr or ""):
-        # Extract module name from "No module named 'requests'"
         import re as _re
 
         match = _re.search(r"No module named ['\"]([^'\"]+)['\"]", result.stderr)
@@ -2180,28 +2180,15 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
                 f"Install '{missing}' and retry?", default=True
             ).ask()
             if install:
-                # Ensure venv exists
-                venv_bin = "Scripts" if sys.platform == "win32" else "bin"
-                if not venv_dir.exists():
-                    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
-                pip_path = venv_dir / venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
-                python_path = str(venv_dir / venv_bin / ("python.exe" if sys.platform == "win32" else "python"))
-
-                # Install the original requirements.txt too if it exists
-                if requirements.exists():
-                    subprocess.run([str(pip_path), "install", "-q", "-r", str(requirements)], check=True)
-                subprocess.run([str(pip_path), "install", "-q", missing], check=True)
+                subprocess.run([str(venv_pip), "install", "-q", missing], check=True)
                 console.print(f"Installed [green]{missing}[/green]. Retrying...")
-
                 result = subprocess.run([python_path, str(script), *script_args])
                 raise SystemExit(result.returncode)
 
-        # If we couldn't parse or user declined, show the original error
         sys.stderr.write(result.stderr)
         sys.stdout.write(result.stdout)
         raise SystemExit(result.returncode)
 
-    # Normal exit — print captured output
     if result.stdout:
         sys.stdout.write(result.stdout)
     if result.stderr:

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2097,6 +2097,12 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     # Discover scripts (prefer stored path from run metadata, fall back to output_dir)
     scripts = discover_scripts(run_id, output_dir, run_metadata=run)
 
+    # Show run info after resolution
+    prompt_preview = (run.get("prompt") or "")[:80]
+    console.print(f"run {run_id} | {prompt_preview}", style="dim")
+    if scripts:
+        console.print(f"  {scripts[0].parent}", style="dim")
+
     if not scripts:
         console.print(f"[red]No Python scripts found for run {run_id}[/red]")
         prompt_preview = (run.get("prompt") or "")[:60]
@@ -2162,9 +2168,6 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     python_path = str(venv_python)
 
     # Execute (with retry on missing imports)
-    prompt_preview = (run.get("prompt") or "")[:80]
-    console.print(f"run {run_id} | {prompt_preview}", style="dim")
-    console.print(f"  {script}", style="dim")
     result = subprocess.run(
         [python_path, str(script), *script_args],
         capture_output=True, text=True,

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2094,8 +2094,8 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     run_id = run["run_id"]
     output_dir = config_manager.get("output_dir")
 
-    # Discover scripts
-    scripts = discover_scripts(run_id, output_dir)
+    # Discover scripts (prefer stored path from run metadata, fall back to output_dir)
+    scripts = discover_scripts(run_id, output_dir, run_metadata=run)
 
     if not scripts:
         console.print(f"[red]No Python scripts found for run {run_id}[/red]")
@@ -2145,11 +2145,12 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts):
     venv_dir = scripts_dir / ".venv"
 
     if requirements.exists():
-        python_path = venv_dir / "bin" / "python"
+        venv_bin = "Scripts" if sys.platform == "win32" else "bin"
+        python_path = venv_dir / venv_bin / ("python.exe" if sys.platform == "win32" else "python")
         if not venv_dir.exists():
             console.print("Installing dependencies...", style="dim")
             subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
-            pip_path = venv_dir / "bin" / "pip"
+            pip_path = venv_dir / venv_bin / ("pip.exe" if sys.platform == "win32" else "pip")
             subprocess.run(
                 [str(pip_path), "install", "-q", "-r", str(requirements)],
                 check=True,

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -665,6 +665,97 @@ def get_visible_save_path(domain: str, base_dir: Path | str, suffix: int = 0) ->
     return path
 
 
+def resolve_run(identifier: str, session_manager) -> dict:
+    """Resolve a run by exact ID or fuzzy prompt/folder name match.
+
+    Args:
+        identifier: Run ID (12-char hex) or search term to fuzzy match
+        session_manager: SessionManager instance to search history
+
+    Returns:
+        The matching run dict
+
+    Raises:
+        click.ClickException: If no match or ambiguous match without TTY
+    """
+    import click
+    import questionary
+
+    # 1. Try exact run_id match
+    run = session_manager.get_run(identifier)
+    if run:
+        return run
+
+    # 2. Fuzzy match against prompt and folder names
+    identifier_lower = identifier.lower()
+    matches = []
+    for run in session_manager.history:
+        prompt = (run.get("prompt") or "").lower()
+        run_id = run.get("run_id", "")
+        # Also check the script folder name from paths
+        script_path = run.get("paths", {}).get("script_path", "")
+        folder_name = Path(script_path).parent.name if script_path else ""
+
+        if identifier_lower in prompt or identifier_lower in folder_name.lower() or identifier_lower in run_id:
+            matches.append(run)
+
+    if not matches:
+        raise click.ClickException(
+            f"No run matching '{identifier}'. Use 'reverse-api-engineer list' to see available runs."
+        )
+
+    if len(matches) == 1:
+        return matches[0]
+
+    # Multiple matches — show picker
+    choices = []
+    for m in matches:
+        prompt_preview = (m.get("prompt") or "")[:50]
+        ts = (m.get("timestamp") or "")[:19]
+        label = f"{m['run_id']}  {ts}  {prompt_preview}"
+        choices.append(questionary.Choice(title=label, value=m))
+
+    selected = questionary.select(
+        f"Multiple runs match '{identifier}':",
+        choices=choices,
+    ).ask()
+
+    if selected is None:
+        raise click.Abort()
+
+    return selected
+
+
+def discover_scripts(run_id: str, output_dir: str | None = None) -> list[Path]:
+    """Find all executable Python scripts in a run's script directory.
+
+    Args:
+        run_id: The run identifier
+        output_dir: Optional custom output directory
+
+    Returns:
+        Sorted list of .py file Paths (excludes __pycache__, .venv, __init__.py)
+    """
+    base_dir = get_base_output_dir(output_dir)
+    scripts_dir = base_dir / "scripts" / run_id
+
+    if not scripts_dir.exists():
+        return []
+
+    exclude_dirs = {"__pycache__", ".venv"}
+    exclude_files = {"__init__.py"}
+
+    scripts = []
+    for f in scripts_dir.iterdir():
+        if f.is_file() and f.suffix == ".py" and f.name not in exclude_files:
+            scripts.append(f)
+        # Don't recurse into excluded dirs
+    # Also skip files inside excluded subdirs (shouldn't happen with iterdir but defensive)
+    scripts = [s for s in scripts if not any(part in exclude_dirs for part in s.parts)]
+
+    return sorted(scripts, key=lambda p: p.name)
+
+
 def extract_domain_from_har(har_path: Path) -> str | None:
     """Extract the primary domain from a HAR file.
 

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -726,18 +726,44 @@ def resolve_run(identifier: str, session_manager) -> dict:
     return selected
 
 
-def discover_scripts(run_id: str, output_dir: str | None = None) -> list[Path]:
+def discover_scripts(run_id: str, output_dir: str | None = None, run_metadata: dict | None = None) -> list[Path]:
     """Find all executable Python scripts in a run's script directory.
+
+    Tries the stored script path from run metadata first, then falls back
+    to the current output_dir config.
 
     Args:
         run_id: The run identifier
         output_dir: Optional custom output directory
+        run_metadata: Optional run dict with paths.script_path to resolve from
 
     Returns:
         Sorted list of .py file Paths (excludes __pycache__, .venv, __init__.py)
+
+    Raises:
+        ValueError: If run_id contains invalid characters
     """
-    base_dir = get_base_output_dir(output_dir)
-    scripts_dir = base_dir / "scripts" / run_id
+    # Validate run_id (same rules as get_scripts_dir)
+    if not run_id:
+        raise ValueError("run_id cannot be empty")
+    if not re.match(r"^[a-zA-Z0-9_-]+$", run_id):
+        raise ValueError(f"Invalid run_id: {run_id}")
+    if len(run_id) > 64:
+        raise ValueError(f"run_id too long: {len(run_id)} characters (max 64)")
+
+    # Try stored path from run metadata first
+    scripts_dir = None
+    if run_metadata:
+        script_path = run_metadata.get("paths", {}).get("script_path", "")
+        if script_path:
+            stored_dir = Path(script_path).parent
+            if stored_dir.exists():
+                scripts_dir = stored_dir
+
+    # Fall back to current output_dir
+    if scripts_dir is None:
+        base_dir = get_base_output_dir(output_dir)
+        scripts_dir = base_dir / "scripts" / run_id
 
     if not scripts_dir.exists():
         return []
@@ -749,8 +775,6 @@ def discover_scripts(run_id: str, output_dir: str | None = None) -> list[Path]:
     for f in scripts_dir.iterdir():
         if f.is_file() and f.suffix == ".py" and f.name not in exclude_files:
             scripts.append(f)
-        # Don't recurse into excluded dirs
-    # Also skip files inside excluded subdirs (shouldn't happen with iterdir but defensive)
     scripts = [s for s in scripts if not any(part in exclude_dirs for part in s.parts)]
 
     return sorted(scripts, key=lambda p: p.name)

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,531 @@
+"""Tests for the `run` command and its supporting functions (resolve_run, discover_scripts)."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from reverse_api.session import SessionManager
+from reverse_api.utils import discover_scripts, resolve_run
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def session_with_runs(tmp_path):
+    """SessionManager with pre-populated runs."""
+    history_path = tmp_path / "history.json"
+    sm = SessionManager(history_path)
+    sm.add_run("abc123def456", "capture the ashby jobs api", mode="manual", paths={"script_path": "/scripts/abc123def456/api_client.py"})
+    sm.add_run("def789ghi012", "go to hubspot and create an api", mode="agent", paths={"script_path": "/scripts/def789ghi012/api_client.py"})
+    sm.add_run("111222333444", "browserbase mp4 recording api", mode="manual", paths={"script_path": "/scripts/111222333444/api_client.py"})
+    return sm
+
+
+@pytest.fixture
+def empty_session(tmp_path):
+    """SessionManager with no runs."""
+    history_path = tmp_path / "history.json"
+    return SessionManager(history_path)
+
+
+@pytest.fixture
+def scripts_dir(tmp_path):
+    """Create a fake scripts directory with multiple .py files."""
+    run_id = "abc123def456"
+    d = tmp_path / "scripts" / run_id
+    d.mkdir(parents=True)
+    (d / "api_client.py").write_text("print('hello from api_client')")
+    (d / "example_usage.py").write_text("print('hello from example')")
+    (d / "README.md").write_text("# docs")
+    (d / "requirements.txt").write_text("requests>=2.28")
+    return d
+
+
+@pytest.fixture
+def scripts_dir_single(tmp_path):
+    """Create a scripts directory with a single .py file."""
+    run_id = "abc123def456"
+    d = tmp_path / "scripts" / run_id
+    d.mkdir(parents=True)
+    (d / "api_client.py").write_text("print('only script')")
+    return d
+
+
+@pytest.fixture
+def scripts_dir_empty(tmp_path):
+    """Create a scripts directory with no .py files."""
+    run_id = "abc123def456"
+    d = tmp_path / "scripts" / run_id
+    d.mkdir(parents=True)
+    (d / "README.md").write_text("# no scripts here")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# resolve_run tests
+# ---------------------------------------------------------------------------
+
+class TestResolveRunExactId:
+    """Test resolve_run with exact run_id matches."""
+
+    def test_exact_match(self, session_with_runs):
+        run = resolve_run("abc123def456", session_with_runs)
+        assert run["run_id"] == "abc123def456"
+
+    def test_exact_match_second_run(self, session_with_runs):
+        run = resolve_run("def789ghi012", session_with_runs)
+        assert run["run_id"] == "def789ghi012"
+
+    def test_exact_match_third_run(self, session_with_runs):
+        run = resolve_run("111222333444", session_with_runs)
+        assert run["run_id"] == "111222333444"
+
+
+class TestResolveRunFuzzyMatch:
+    """Test resolve_run with fuzzy prompt/name matching."""
+
+    def test_unique_prompt_match(self, session_with_runs):
+        run = resolve_run("ashby", session_with_runs)
+        assert run["run_id"] == "abc123def456"
+
+    def test_no_match_raises(self, session_with_runs):
+        with pytest.raises(click.ClickException, match="No run matching"):
+            resolve_run("nonexistent_xyz", session_with_runs)
+
+    def test_no_match_error_message_includes_identifier(self, session_with_runs):
+        with pytest.raises(click.ClickException, match="zzzznotfound"):
+            resolve_run("zzzznotfound", session_with_runs)
+
+    def test_empty_history_raises(self, empty_session):
+        with pytest.raises(click.ClickException, match="No run matching"):
+            resolve_run("anything", empty_session)
+
+    def test_case_insensitive_match(self, session_with_runs):
+        run = resolve_run("ASHBY", session_with_runs)
+        assert run["run_id"] == "abc123def456"
+
+    def test_partial_run_id_match(self, session_with_runs):
+        """Partial run_id substring should match via fuzzy search."""
+        run = resolve_run("abc123", session_with_runs)
+        assert run["run_id"] == "abc123def456"
+
+    def test_multiple_matches_shows_picker(self, session_with_runs):
+        """When multiple runs match, questionary picker is shown."""
+        # "api" appears in all three prompts
+        with patch("questionary.Choice", side_effect=lambda **kw: kw):
+            with patch("questionary.select") as mock_select:
+                mock_select.return_value.ask.return_value = session_with_runs.history[0]
+                run = resolve_run("api", session_with_runs)
+                mock_select.assert_called_once()
+                assert run is not None
+
+    def test_multiple_matches_user_cancels(self, session_with_runs):
+        """When user cancels the picker, click.Abort is raised."""
+        with patch("questionary.Choice", side_effect=lambda **kw: kw):
+            with patch("questionary.select") as mock_select:
+                mock_select.return_value.ask.return_value = None
+                with pytest.raises(click.Abort):
+                    resolve_run("api", session_with_runs)
+
+    def test_matches_folder_name_from_paths(self, tmp_path):
+        """Matches against folder name derived from paths.script_path."""
+        history_path = tmp_path / "history.json"
+        sm = SessionManager(history_path)
+        sm.add_run("aaa111bbb222", "some generic prompt", paths={"script_path": "/scripts/aaa111bbb222/ashby_jobs_api/api_client.py"})
+        # "ashby_jobs" should match the folder name in the path
+        run = resolve_run("ashby_jobs", sm)
+        assert run["run_id"] == "aaa111bbb222"
+
+    def test_match_against_prompt_substring(self, tmp_path):
+        """Matches substring within prompt text."""
+        history_path = tmp_path / "history.json"
+        sm = SessionManager(history_path)
+        sm.add_run("xyz123", "go to stripe.com and reverse engineer the billing api")
+        run = resolve_run("stripe", sm)
+        assert run["run_id"] == "xyz123"
+
+    def test_match_is_case_insensitive_on_prompt(self, tmp_path):
+        """Case-insensitive matching on prompt content."""
+        history_path = tmp_path / "history.json"
+        sm = SessionManager(history_path)
+        sm.add_run("xyz123", "Go to GitHub.com and capture API")
+        run = resolve_run("github", sm)
+        assert run["run_id"] == "xyz123"
+
+
+# ---------------------------------------------------------------------------
+# discover_scripts tests
+# ---------------------------------------------------------------------------
+
+class TestDiscoverScripts:
+    """Test discover_scripts function."""
+
+    def test_finds_py_files(self, scripts_dir, tmp_path):
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        names = [s.name for s in scripts]
+        assert "api_client.py" in names
+        assert "example_usage.py" in names
+
+    def test_excludes_non_py(self, scripts_dir, tmp_path):
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        names = [s.name for s in scripts]
+        assert "README.md" not in names
+        assert "requirements.txt" not in names
+
+    def test_excludes_init(self, scripts_dir, tmp_path):
+        (scripts_dir / "__init__.py").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        names = [s.name for s in scripts]
+        assert "__init__.py" not in names
+
+    def test_excludes_venv_files(self, scripts_dir, tmp_path):
+        venv = scripts_dir / ".venv"
+        venv.mkdir()
+        (venv / "some_script.py").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        for s in scripts:
+            assert ".venv" not in str(s)
+
+    def test_empty_dir_returns_empty(self, scripts_dir_empty, tmp_path):
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert scripts == []
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path):
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("doesnotexist999")
+        assert scripts == []
+
+    def test_sorted_by_name(self, scripts_dir, tmp_path):
+        (scripts_dir / "zzz_last.py").write_text("")
+        (scripts_dir / "aaa_first.py").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        names = [s.name for s in scripts]
+        assert names == sorted(names)
+
+    def test_custom_output_dir(self, tmp_path):
+        custom = tmp_path / "custom_out"
+        d = custom / "scripts" / "run1"
+        d.mkdir(parents=True)
+        (d / "main.py").write_text("print('hi')")
+        scripts = discover_scripts("run1", output_dir=str(custom))
+        assert len(scripts) == 1
+        assert scripts[0].name == "main.py"
+
+    def test_single_script(self, scripts_dir_single, tmp_path):
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert len(scripts) == 1
+        assert scripts[0].name == "api_client.py"
+
+    def test_pycache_dir_contents_excluded(self, scripts_dir, tmp_path):
+        cache = scripts_dir / "__pycache__"
+        cache.mkdir()
+        (cache / "module.cpython-313.pyc").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        for s in scripts:
+            assert "__pycache__" not in str(s)
+
+
+# ---------------------------------------------------------------------------
+# CLI `run` command integration tests (using Click's CliRunner)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_cli_env(tmp_path, session_with_runs):
+    """Patch the module-level globals in cli.py for testing."""
+    scripts_dir = tmp_path / "scripts" / "abc123def456"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "api_client.py").write_text("import sys; print('args:', sys.argv[1:])")
+    (scripts_dir / "example_usage.py").write_text("print('example')")
+
+    # Single-script run
+    scripts_dir2 = tmp_path / "scripts" / "def789ghi012"
+    scripts_dir2.mkdir(parents=True)
+    (scripts_dir2 / "api_client.py").write_text("print('hubspot client')")
+
+    # Empty run (no .py files)
+    scripts_dir3 = tmp_path / "scripts" / "111222333444"
+    scripts_dir3.mkdir(parents=True)
+
+    patches = [
+        patch("reverse_api.cli.session_manager", session_with_runs),
+        patch("reverse_api.cli.config_manager", MagicMock(get=MagicMock(return_value=None))),
+        patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path),
+    ]
+    for p in patches:
+        p.start()
+    yield tmp_path, session_with_runs
+    for p in patches:
+        p.stop()
+
+
+class TestRunCommandHelp:
+    """Test --help and basic CLI parsing."""
+
+    def test_help_output(self, cli_runner):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "IDENTIFIER" in result.output
+        assert "--ls" in result.output
+        assert "--file" in result.output
+
+    def test_help_shows_examples(self, cli_runner):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "--help"])
+        assert "reverse-api-engineer run" in result.output
+
+
+class TestRunCommandLs:
+    """Test --ls flag."""
+
+    def test_ls_shows_scripts(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "abc123def456", "--ls"])
+        assert result.exit_code == 0
+        assert "api_client.py" in result.output
+        assert "example_usage.py" in result.output
+
+    def test_ls_shows_file_sizes(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "abc123def456", "--ls"])
+        assert "Size" in result.output
+        assert "Modified" in result.output
+        assert "B" in result.output
+
+    def test_ls_no_scripts_error(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "111222333444", "--ls"])
+        assert result.exit_code == 1
+        assert "No Python scripts" in result.output
+
+    def test_ls_with_fuzzy_name(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "ashby", "--ls"])
+        assert result.exit_code == 0
+        assert "api_client.py" in result.output
+
+    def test_ls_does_not_execute(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run") as mock_sub:
+            result = cli_runner.invoke(main, ["run", "abc123def456", "--ls"])
+        mock_sub.assert_not_called()
+
+
+class TestRunCommandFileFlag:
+    """Test --file flag."""
+
+    def test_file_flag_selects_script(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "abc123def456", "--file", "example_usage.py"])
+        assert mock_sub.called
+        call_args = mock_sub.call_args[0][0]
+        assert "example_usage.py" in str(call_args[1])
+
+    def test_file_flag_nonexistent_file(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "abc123def456", "--file", "nope.py"])
+        assert result.exit_code != 0
+        assert "nope.py" in result.output
+        assert "Available" in result.output
+
+    def test_file_flag_lists_available_on_error(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "abc123def456", "--file", "missing.py"])
+        assert "api_client.py" in result.output
+        assert "example_usage.py" in result.output
+
+
+class TestRunCommandExecution:
+    """Test actual script execution."""
+
+    def test_single_script_auto_selected(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert mock_sub.called
+        call_args = mock_sub.call_args[0][0]
+        assert "api_client.py" in str(call_args[1])
+
+    def test_args_passthrough(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012", "--", "--org", "acme", "--limit", "10"])
+        call_args = mock_sub.call_args[0][0]
+        assert "--org" in call_args
+        assert "acme" in call_args
+        assert "--limit" in call_args
+        assert "10" in call_args
+
+    def test_exit_code_forwarded(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=42)):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert result.exit_code == 42
+
+    def test_exit_code_zero_on_success(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert result.exit_code == 0
+
+    def test_multiple_scripts_shows_picker(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        script_path = tmp_path / "scripts" / "abc123def456" / "api_client.py"
+        with patch("questionary.Choice", side_effect=lambda **kw: kw):
+            with patch("questionary.select") as mock_select:
+                mock_select.return_value.ask.return_value = script_path
+                with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+                    result = cli_runner.invoke(main, ["run", "abc123def456"])
+                mock_select.assert_called_once()
+
+    def test_multiple_scripts_user_cancels_picker(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("questionary.Choice", side_effect=lambda **kw: kw):
+            with patch("questionary.select") as mock_select:
+                mock_select.return_value.ask.return_value = None
+                result = cli_runner.invoke(main, ["run", "abc123def456"])
+        assert result.exit_code != 0
+
+
+class TestRunCommandNoScripts:
+    """Test error handling when no scripts exist."""
+
+    def test_no_scripts_shows_error(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "111222333444"])
+        assert result.exit_code == 1
+        assert "No Python scripts" in result.output
+
+    def test_no_scripts_shows_prompt_preview(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "111222333444"])
+        assert "browserbase" in result.output
+
+    def test_no_matching_run(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        result = cli_runner.invoke(main, ["run", "totallynonexistent"])
+        assert result.exit_code != 0
+        assert "No run matching" in result.output
+
+
+class TestRunCommandVenv:
+    """Test venv and dependency management."""
+
+    def test_creates_venv_when_requirements_exist(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
+        req.write_text("requests>=2.28")
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+
+        # Should have called subprocess.run 3 times: venv create, pip install, script run
+        assert mock_sub.call_count == 3
+        calls = mock_sub.call_args_list
+
+        # First call: create venv
+        assert "-m" in calls[0][0][0]
+        assert "venv" in calls[0][0][0]
+
+        # Second call: pip install
+        pip_args = calls[1][0][0]
+        assert "pip" in str(pip_args[0])
+        assert "-r" in pip_args
+
+        # Third call: actual script, using venv python
+        python_path = str(calls[2][0][0][0])
+        assert ".venv" in python_path
+
+    def test_skips_venv_when_already_exists(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        scripts = tmp_path / "scripts" / "def789ghi012"
+        req = scripts / "requirements.txt"
+        req.write_text("requests>=2.28")
+        # Pre-create venv
+        venv = scripts / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+
+        # Should only call subprocess.run once (just the script), no venv/pip
+        assert mock_sub.call_count == 1
+
+    def test_no_venv_without_requirements(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+
+        # Should call subprocess.run exactly once (just the script, no venv/pip)
+        assert mock_sub.call_count == 1
+        # Should NOT have created a venv inside the scripts dir
+        tmp_path = mock_cli_env[0]
+        venv_path = tmp_path / "scripts" / "def789ghi012" / ".venv"
+        assert not venv_path.exists()
+
+    def test_venv_uses_requirements_txt_path(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
+        req.write_text("httpx>=0.25\nbeautifulsoup4")
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+
+        # pip install call should reference the requirements.txt
+        pip_call = mock_sub.call_args_list[1][0][0]
+        assert str(req) in [str(a) for a in pip_call]
+
+
+class TestRunCommandOutputMessages:
+    """Test user-facing output messages."""
+
+    def test_shows_running_message(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert "Running" in result.output
+        assert "api_client.py" in result.output
+
+    def test_shows_run_id_in_output(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert "def789ghi012" in result.output
+
+    def test_installing_deps_message(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
+        req.write_text("requests")
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert "Installing dependencies" in result.output
+        assert "Dependencies installed" in result.output

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -563,12 +563,11 @@ class TestRunCommandImportRetry:
         (venv / "bin" / "python").write_text("#!/bin/sh")
         (venv / "bin" / "pip").write_text("#!/bin/sh")
 
-        # 1st call: real-time run fails, 2nd: probe with captured stderr, 3rd: pip install, 4th: retry succeeds
-        first_run = MagicMock(returncode=1)
-        probe = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'pandas'")
+        # 1st call: run with captured stderr fails, 2nd: pip install, 3rd: retry succeeds
+        first_run = MagicMock(returncode=1, stderr="ModuleNotFoundError: No module named 'pandas'")
         pip_ok = MagicMock(returncode=0, stdout="", stderr="")
         retry_ok = MagicMock(returncode=0)
-        with patch("subprocess.run", side_effect=[first_run, probe, pip_ok, retry_ok]):
+        with patch("subprocess.run", side_effect=[first_run, pip_ok, retry_ok]):
             with patch("questionary.confirm") as mock_confirm:
                 mock_confirm.return_value.ask.return_value = True
                 result = cli_runner.invoke(main, ["run", "def789ghi012"])
@@ -584,9 +583,8 @@ class TestRunCommandImportRetry:
         (venv / "bin" / "python").write_text("#!/bin/sh")
         (venv / "bin" / "pip").write_text("#!/bin/sh")
 
-        first_run = MagicMock(returncode=1)
-        probe = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'foo'")
-        with patch("subprocess.run", side_effect=[first_run, probe]):
+        first_run = MagicMock(returncode=1, stderr="ModuleNotFoundError: No module named 'foo'")
+        with patch("subprocess.run", side_effect=[first_run]):
             with patch("questionary.confirm") as mock_confirm:
                 mock_confirm.return_value.ask.return_value = False
                 result = cli_runner.invoke(main, ["run", "def789ghi012"])
@@ -600,9 +598,8 @@ class TestRunCommandImportRetry:
         (venv / "bin").mkdir()
         (venv / "bin" / "python").write_text("#!/bin/sh")
 
-        first_run = MagicMock(returncode=1)
-        probe = MagicMock(returncode=1, stdout="", stderr="TypeError: something else broke")
-        with patch("subprocess.run", side_effect=[first_run, probe]):
+        first_run = MagicMock(returncode=1, stderr="TypeError: something else broke")
+        with patch("subprocess.run", side_effect=[first_run]):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert result.exit_code == 1
 

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -618,8 +618,7 @@ class TestRunCommandOutputMessages:
 
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
-        assert "run def789ghi012" in result.output
-        assert "hubspot" in result.output
+        assert "scripts/def789ghi012" in result.output
 
     def test_shows_run_id_in_output(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -381,7 +381,7 @@ class TestRunCommandFileFlag:
 
     def test_file_flag_selects_script(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "abc123def456", "--file", "example_usage.py"])
         assert mock_sub.called
         call_args = mock_sub.call_args[0][0]
@@ -406,7 +406,7 @@ class TestRunCommandExecution:
 
     def test_single_script_auto_selected(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert mock_sub.called
         call_args = mock_sub.call_args[0][0]
@@ -414,7 +414,7 @@ class TestRunCommandExecution:
 
     def test_args_passthrough(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012", "--", "--org", "acme", "--limit", "10"])
         call_args = mock_sub.call_args[0][0]
         assert "--org" in call_args
@@ -424,13 +424,13 @@ class TestRunCommandExecution:
 
     def test_exit_code_forwarded(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=42)):
+        with patch("subprocess.run", return_value=MagicMock(returncode=42, stdout="", stderr="err")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert result.exit_code == 42
 
     def test_exit_code_zero_on_success(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="ok", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert result.exit_code == 0
 
@@ -441,7 +441,7 @@ class TestRunCommandExecution:
         with patch("questionary.Choice", side_effect=lambda **kw: kw):
             with patch("questionary.select") as mock_select:
                 mock_select.return_value.ask.return_value = script_path
-                with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+                with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                     result = cli_runner.invoke(main, ["run", "abc123def456"])
                 mock_select.assert_called_once()
 
@@ -484,7 +484,7 @@ class TestRunCommandVenv:
         req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
         req.write_text("requests>=2.28")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
         # Should have called subprocess.run 3 times: venv create, pip install, script run
@@ -516,7 +516,7 @@ class TestRunCommandVenv:
         (venv / "bin").mkdir()
         (venv / "bin" / "python").write_text("#!/bin/sh")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
         # Should only call subprocess.run once (just the script), no venv/pip
@@ -524,7 +524,7 @@ class TestRunCommandVenv:
 
     def test_no_venv_without_requirements(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
         # Should call subprocess.run exactly once (just the script, no venv/pip)
@@ -540,7 +540,7 @@ class TestRunCommandVenv:
         req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
         req.write_text("httpx>=0.25\nbeautifulsoup4")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_sub:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
         # pip install call should reference the requirements.txt
@@ -548,19 +548,51 @@ class TestRunCommandVenv:
         assert str(req) in [str(a) for a in pip_call]
 
 
+class TestRunCommandImportRetry:
+    """Test automatic retry on ModuleNotFoundError."""
+
+    def test_offers_install_on_import_error(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        failed = MagicMock(returncode=1, stdout="", stderr="Traceback (most recent call last):\nModuleNotFoundError: No module named 'requests'")
+        success = MagicMock(returncode=0, stdout="ok", stderr="")
+        with patch("subprocess.run", side_effect=[failed, MagicMock(returncode=0, stdout="", stderr=""), MagicMock(returncode=0, stdout="", stderr=""), MagicMock(returncode=0, stdout="", stderr=""), success]) as mock_sub:
+            with patch("questionary.confirm") as mock_confirm:
+                mock_confirm.return_value.ask.return_value = True
+                result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert "Missing dependency: requests" in result.output
+        assert "Installed" in result.output
+
+    def test_user_declines_install(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        failed = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'foo'")
+        with patch("subprocess.run", return_value=failed):
+            with patch("questionary.confirm") as mock_confirm:
+                mock_confirm.return_value.ask.return_value = False
+                result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert result.exit_code == 1
+
+    def test_non_import_error_passes_through(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        failed = MagicMock(returncode=1, stdout="", stderr="TypeError: something else broke")
+        with patch("subprocess.run", return_value=failed):
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+        assert result.exit_code == 1
+        assert "TypeError" in result.output
+
+
 class TestRunCommandOutputMessages:
     """Test user-facing output messages."""
 
     def test_shows_running_message(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert "Running" in result.output
         assert "api_client.py" in result.output
 
     def test_shows_run_id_in_output(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert "def789ghi012" in result.output
 
@@ -570,7 +602,7 @@ class TestRunCommandOutputMessages:
         req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
         req.write_text("requests")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert "Installing dependencies" in result.output
         assert "Dependencies installed" in result.output

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -557,17 +557,18 @@ class TestRunCommandImportRetry:
     def test_offers_install_on_import_error(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
         tmp_path = mock_cli_env[0]
-        # Pre-create shared venv so setup is skipped
         venv = tmp_path / ".venv"
         venv.mkdir()
         (venv / "bin").mkdir()
         (venv / "bin" / "python").write_text("#!/bin/sh")
         (venv / "bin" / "pip").write_text("#!/bin/sh")
 
-        failed = MagicMock(returncode=1, stdout="", stderr="Traceback:\nModuleNotFoundError: No module named 'pandas'")
+        # 1st call: real-time run fails, 2nd: probe with captured stderr, 3rd: pip install, 4th: retry succeeds
+        first_run = MagicMock(returncode=1)
+        probe = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'pandas'")
         pip_ok = MagicMock(returncode=0, stdout="", stderr="")
-        success = MagicMock(returncode=0, stdout="ok", stderr="")
-        with patch("subprocess.run", side_effect=[failed, pip_ok, success]):
+        retry_ok = MagicMock(returncode=0)
+        with patch("subprocess.run", side_effect=[first_run, probe, pip_ok, retry_ok]):
             with patch("questionary.confirm") as mock_confirm:
                 mock_confirm.return_value.ask.return_value = True
                 result = cli_runner.invoke(main, ["run", "def789ghi012"])
@@ -583,8 +584,9 @@ class TestRunCommandImportRetry:
         (venv / "bin" / "python").write_text("#!/bin/sh")
         (venv / "bin" / "pip").write_text("#!/bin/sh")
 
-        failed = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'foo'")
-        with patch("subprocess.run", return_value=failed):
+        first_run = MagicMock(returncode=1)
+        probe = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'foo'")
+        with patch("subprocess.run", side_effect=[first_run, probe]):
             with patch("questionary.confirm") as mock_confirm:
                 mock_confirm.return_value.ask.return_value = False
                 result = cli_runner.invoke(main, ["run", "def789ghi012"])
@@ -598,11 +600,11 @@ class TestRunCommandImportRetry:
         (venv / "bin").mkdir()
         (venv / "bin" / "python").write_text("#!/bin/sh")
 
-        failed = MagicMock(returncode=1, stdout="", stderr="TypeError: something else broke")
-        with patch("subprocess.run", return_value=failed):
+        first_run = MagicMock(returncode=1)
+        probe = MagicMock(returncode=1, stdout="", stderr="TypeError: something else broke")
+        with patch("subprocess.run", side_effect=[first_run, probe]):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert result.exit_code == 1
-        assert "TypeError" in result.output
 
 
 class TestRunCommandOutputMessages:

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -239,6 +239,51 @@ class TestDiscoverScripts:
         for s in scripts:
             assert "__pycache__" not in str(s)
 
+    def test_empty_run_id_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            discover_scripts("")
+
+    def test_invalid_run_id_raises(self):
+        with pytest.raises(ValueError, match="Invalid run_id"):
+            discover_scripts("../../../etc")
+
+    def test_too_long_run_id_raises(self):
+        with pytest.raises(ValueError, match="too long"):
+            discover_scripts("a" * 65)
+
+
+class TestDiscoverScriptsRunMetadata:
+    """Test discover_scripts with run_metadata (stored path) fallback."""
+
+    def test_uses_stored_path_from_metadata(self, tmp_path):
+        """Prefers the stored script_path from run metadata over output_dir."""
+        stored_dir = tmp_path / "old_output" / "scripts" / "run1"
+        stored_dir.mkdir(parents=True)
+        (stored_dir / "api_client.py").write_text("print('stored')")
+
+        metadata = {"paths": {"script_path": str(stored_dir / "api_client.py")}}
+        # output_dir points somewhere else entirely
+        scripts = discover_scripts("run1", output_dir=str(tmp_path / "new_output"), run_metadata=metadata)
+        assert len(scripts) == 1
+        assert scripts[0].parent == stored_dir
+
+    def test_falls_back_to_output_dir_when_stored_missing(self, tmp_path):
+        """Falls back to output_dir when stored path doesn't exist."""
+        fallback_dir = tmp_path / "scripts" / "run1"
+        fallback_dir.mkdir(parents=True)
+        (fallback_dir / "api_client.py").write_text("print('fallback')")
+
+        metadata = {"paths": {"script_path": "/nonexistent/path/api_client.py"}}
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("run1", run_metadata=metadata)
+        assert len(scripts) == 1
+
+    def test_falls_back_when_no_metadata(self, scripts_dir, tmp_path):
+        """Works without run_metadata (backwards compatible)."""
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456", run_metadata=None)
+        assert len(scripts) >= 1
+
 
 # ---------------------------------------------------------------------------
 # CLI `run` command integration tests (using Click's CliRunner)

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -618,8 +618,8 @@ class TestRunCommandOutputMessages:
 
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
-        assert "Running" in result.output
-        assert "api_client.py" in result.output
+        assert "run def789ghi012" in result.output
+        assert "hubspot" in result.output
 
     def test_shows_run_id_in_output(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -475,77 +475,80 @@ class TestRunCommandNoScripts:
         assert "No run matching" in result.output
 
 
-class TestRunCommandVenv:
-    """Test venv and dependency management."""
+class TestRunCommandSharedVenv:
+    """Test shared venv and dependency management."""
 
-    def test_creates_venv_when_requirements_exist(self, cli_runner, mock_cli_env):
+    def test_creates_shared_venv_on_first_run(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        tmp_path = mock_cli_env[0]
-        req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
-        req.write_text("requests>=2.28")
-
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=ok) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
-        # Should have called subprocess.run 3 times: venv create, pip install, script run
+        # Should have: venv create, pip install requests, script run = 3 calls
         assert mock_sub.call_count == 3
-        calls = mock_sub.call_args_list
-
         # First call: create venv
-        assert "-m" in calls[0][0][0]
-        assert "venv" in calls[0][0][0]
+        assert "venv" in mock_sub.call_args_list[0][0][0]
+        # Second call: pip install requests
+        pip_args = mock_sub.call_args_list[1][0][0]
+        assert "requests" in pip_args
+        # Third call: script runs with venv python
+        assert ".venv" in str(mock_sub.call_args_list[2][0][0][0])
 
-        # Second call: pip install
-        pip_args = calls[1][0][0]
-        assert "pip" in str(pip_args[0])
-        assert "-r" in pip_args
-
-        # Third call: actual script, using venv python
-        python_path = str(calls[2][0][0][0])
-        assert ".venv" in python_path
-
-    def test_skips_venv_when_already_exists(self, cli_runner, mock_cli_env):
+    def test_skips_venv_creation_when_exists(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
         tmp_path = mock_cli_env[0]
-        scripts = tmp_path / "scripts" / "def789ghi012"
-        req = scripts / "requirements.txt"
-        req.write_text("requests>=2.28")
-        # Pre-create venv
-        venv = scripts / ".venv"
+        # Pre-create shared venv
+        venv = tmp_path / ".venv"
         venv.mkdir()
         (venv / "bin").mkdir()
         (venv / "bin" / "python").write_text("#!/bin/sh")
+        (venv / "bin" / "pip").write_text("#!/bin/sh")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=ok) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
-        # Should only call subprocess.run once (just the script), no venv/pip
+        # Only the script execution call — no venv create, no pip install
         assert mock_sub.call_count == 1
 
-    def test_no_venv_without_requirements(self, cli_runner, mock_cli_env):
-        from reverse_api.cli import main
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
-            result = cli_runner.invoke(main, ["run", "def789ghi012"])
-
-        # Should call subprocess.run exactly once (just the script, no venv/pip)
-        assert mock_sub.call_count == 1
-        # Should NOT have created a venv inside the scripts dir
-        tmp_path = mock_cli_env[0]
-        venv_path = tmp_path / "scripts" / "def789ghi012" / ".venv"
-        assert not venv_path.exists()
-
-    def test_venv_uses_requirements_txt_path(self, cli_runner, mock_cli_env):
+    def test_installs_per_run_requirements(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
         tmp_path = mock_cli_env[0]
+        # Pre-create shared venv
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+        (venv / "bin" / "pip").write_text("#!/bin/sh")
+
         req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
-        req.write_text("httpx>=0.25\nbeautifulsoup4")
+        req.write_text("httpx>=0.25")
 
-        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_sub:
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=ok) as mock_sub:
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
 
-        # pip install call should reference the requirements.txt
-        pip_call = mock_sub.call_args_list[1][0][0]
+        # pip install -r requirements.txt + script run = 2 calls
+        assert mock_sub.call_count == 2
+        pip_call = mock_sub.call_args_list[0][0][0]
+        assert "-r" in pip_call
         assert str(req) in [str(a) for a in pip_call]
+
+    def test_uses_venv_python_for_execution(self, cli_runner, mock_cli_env):
+        from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+        (venv / "bin" / "pip").write_text("#!/bin/sh")
+
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=ok) as mock_sub:
+            result = cli_runner.invoke(main, ["run", "def789ghi012"])
+
+        script_call = mock_sub.call_args_list[-1][0][0]
+        assert ".venv" in str(script_call[0])
 
 
 class TestRunCommandImportRetry:
@@ -553,17 +556,33 @@ class TestRunCommandImportRetry:
 
     def test_offers_install_on_import_error(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        failed = MagicMock(returncode=1, stdout="", stderr="Traceback (most recent call last):\nModuleNotFoundError: No module named 'requests'")
+        tmp_path = mock_cli_env[0]
+        # Pre-create shared venv so setup is skipped
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+        (venv / "bin" / "pip").write_text("#!/bin/sh")
+
+        failed = MagicMock(returncode=1, stdout="", stderr="Traceback:\nModuleNotFoundError: No module named 'pandas'")
+        pip_ok = MagicMock(returncode=0, stdout="", stderr="")
         success = MagicMock(returncode=0, stdout="ok", stderr="")
-        with patch("subprocess.run", side_effect=[failed, MagicMock(returncode=0, stdout="", stderr=""), MagicMock(returncode=0, stdout="", stderr=""), MagicMock(returncode=0, stdout="", stderr=""), success]) as mock_sub:
+        with patch("subprocess.run", side_effect=[failed, pip_ok, success]):
             with patch("questionary.confirm") as mock_confirm:
                 mock_confirm.return_value.ask.return_value = True
                 result = cli_runner.invoke(main, ["run", "def789ghi012"])
-        assert "Missing dependency: requests" in result.output
+        assert "Missing dependency: pandas" in result.output
         assert "Installed" in result.output
 
     def test_user_declines_install(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+        (venv / "bin" / "pip").write_text("#!/bin/sh")
+
         failed = MagicMock(returncode=1, stdout="", stderr="ModuleNotFoundError: No module named 'foo'")
         with patch("subprocess.run", return_value=failed):
             with patch("questionary.confirm") as mock_confirm:
@@ -573,6 +592,12 @@ class TestRunCommandImportRetry:
 
     def test_non_import_error_passes_through(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+
         failed = MagicMock(returncode=1, stdout="", stderr="TypeError: something else broke")
         with patch("subprocess.run", return_value=failed):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
@@ -585,6 +610,12 @@ class TestRunCommandOutputMessages:
 
     def test_shows_running_message(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert "Running" in result.output
@@ -592,17 +623,19 @@ class TestRunCommandOutputMessages:
 
     def test_shows_run_id_in_output(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
+        tmp_path = mock_cli_env[0]
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/sh")
+
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
         assert "def789ghi012" in result.output
 
-    def test_installing_deps_message(self, cli_runner, mock_cli_env):
+    def test_shared_venv_setup_message(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
-        tmp_path = mock_cli_env[0]
-        req = tmp_path / "scripts" / "def789ghi012" / "requirements.txt"
-        req.write_text("requests")
-
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
             result = cli_runner.invoke(main, ["run", "def789ghi012"])
-        assert "Installing dependencies" in result.output
-        assert "Dependencies installed" in result.output
+        assert "Setting up shared venv" in result.output
+        assert "Shared venv ready" in result.output


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `run` CLI command to execute previously generated Python scripts in one step using a shared venv. It shows the run ID, timestamp, prompt preview, and scripts directory in dim text before selection, streams stdout live, and captures stderr once to detect and auto-install missing imports (including sub-modules) without re-running the script.

- **New Features**
  - `reverse-api-engineer run <id|search> [--ls] [--file <name>] [-- ...args]` to list or run scripts; forwards args after `--`.
  - Fuzzy match by run ID, prompt text, or script folder; interactive picker if multiple match.
  - `--ls` lists scripts with size and modified time; `--file` runs a specific script.
  - Uses a shared venv at `~/.reverse-api/runs/.venv` with `requests` pre-installed; installs per-run `requirements.txt`; on `ModuleNotFoundError`, offers to install missing packages and retries.

- **Bug Fixes**
  - Capture stderr during the first run to detect `ModuleNotFoundError`, preventing double execution and duplicate side effects.
  - Prefer stored `paths.script_path` when resolving scripts; fall back to current `output_dir`.
  - Platform-safe venv executable paths and run ID validation to prevent invalid characters/path traversal.
  - When the missing import is a sub-module (e.g., `requests.auth`), install the top-level package (`requests`) instead of failing on an invalid requirement.

<sup>Written for commit a53c87de8eb814c6aca4558260b88e03ee829f59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `run` CLI command to execute previously generated scripts in a shared venv, with fuzzy run matching, `--ls`/`--file` flags, auto dependency installation on `ModuleNotFoundError`, and real-time stdout streaming with captured stderr to avoid double execution.

- **P1**: When `ModuleNotFoundError` names a sub-module (e.g., `requests.auth`), the extracted string is passed directly to `pip install` with `check=True`; pip rejects the dotted name as an invalid requirement and raises `subprocess.CalledProcessError` as an unhandled traceback instead of a user-friendly retry prompt.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the sub-module pip install crash in the ModuleNotFoundError retry path

One P1 logic bug: sub-module import names (e.g. requests.auth) extracted from stderr are passed directly to pip install with check=True, which raises CalledProcessError on invalid package names. All other findings are P2.

src/reverse_api/cli.py lines 2180–2189 (sub-module extraction before pip install)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/cli.py | Adds run command with venv management and auto-retry; sub-module extraction bug in pip install error path |
| src/reverse_api/utils.py | Adds resolve_run and discover_scripts helpers with correct run ID validation and stored-path fallback logic |
| tests/test_run_command.py | Comprehensive test suite covering all main paths (--ls, --file, venv setup, import retry) for the new run command |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/reverse_api/cli.py
Line: 2180-2189

Comment:
**Sub-module path crashes `pip install` with `check=True`**

When Python reports `No module named 'requests.auth'` (or any dotted sub-module), `missing` becomes `requests.auth`. Running `pip install requests.auth` exits non-zero because it is not a valid PyPI package name; with `check=True` this raises `subprocess.CalledProcessError` as an unhandled traceback rather than a helpful prompt. Strip the dotted suffix before calling pip.

```suggestion
                missing_raw = match.group(1)
                missing = missing_raw.split(".")[0]  # top-level package only
                console.print(f"[yellow]Missing dependency: {missing_raw}[/yellow]")

                install = questionary.confirm(
                    f"Install '{missing}' and retry?", default=True
                ).ask()
                if install:
                    subprocess.run([str(venv_pip), "install", "-q", missing], check=True)
                    console.print(f"Installed [green]{missing}[/green]. Retrying...")
                    result = subprocess.run(cmd)
                    raise SystemExit(result.returncode)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/reverse_api/cli.py
Line: 2154

Comment:
**Venv check only tests directory existence**

If `.venv` exists as a directory but `bin/python` is absent (corrupted venv, stale empty dir left by a prior failed creation), the code skips creation and later runs the non-existent executable, producing a confusing `FileNotFoundError`. Checking the executable directly is more robust.

```suggestion
    if not venv_python.exists():
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (3): Last reviewed commit: ["fix: capture stderr only to avoid double..."](https://github.com/kalil0321/reverse-api-engineer/commit/5218e8754b99f88d383d84ccf9e3264a45d3aa5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27435637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->