### PR TITLE
M2: CA persistence + Keychain trust + system proxy toggle

### DIFF
--- a/macos/Sources/ReverseAPIProxy/CA/CAStore.swift
+++ b/macos/Sources/ReverseAPIProxy/CA/CAStore.swift
@@ -6,9 +6,12 @@ import Security
 
 public enum CAStoreError: Error {
     case missingCertificateOnDisk
+    case missingPrivateKeyInKeychain
     case keychainWriteFailed(OSStatus)
     case keychainReadFailed(OSStatus)
+    case keychainDeleteFailed(OSStatus)
     case invalidStoredPrivateKey
+    case certificateDeleteFailed(any Error)
 }
 
 public final class CAStore: @unchecked Sendable {
@@ -26,11 +29,16 @@ public final class CAStore: @unchecked Sendable {
     }
 
     public func loadOrCreate() throws -> RootCertificate {
-        if let existing = try? load() { return existing }
+        if exists() {
+            return try load()
+        }
         return try createAndStore()
     }
 
     public func load() throws -> RootCertificate {
+        guard FileManager.default.fileExists(atPath: certificateURL.path) else {
+            throw CAStoreError.missingCertificateOnDisk
+        }
         let derBytes = try Data(contentsOf: certificateURL)
         let certificate = try Certificate(derEncoded: Array(derBytes))
         let pemData = try loadPrivateKeyPEM()
@@ -50,13 +58,20 @@ public final class CAStore: @unchecked Sendable {
     }
 
     public func reset() throws {
-        try? FileManager.default.removeItem(at: certificateURL)
+        let manager = FileManager.default
+        if manager.fileExists(atPath: certificateURL.path) {
+            do {
+                try manager.removeItem(at: certificateURL)
+            } catch {
+                throw CAStoreError.certificateDeleteFailed(error)
+            }
+        }
         try deletePrivateKey()
     }
 
     public func exists() -> Bool {
         guard FileManager.default.fileExists(atPath: certificateURL.path) else { return false }
-        return (try? loadPrivateKeyPEM()) != nil
+        return privateKeyExists()
     }
 
     private func storePrivateKeyPEM(_ data: Data) throws {
@@ -65,7 +80,10 @@ public final class CAStore: @unchecked Sendable {
             kSecAttrService as String: keychainService,
             kSecAttrAccount as String: keychainAccount,
         ]
-        SecItemDelete(query as CFDictionary)
+        let deleteStatus = SecItemDelete(query as CFDictionary)
+        if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
+            throw CAStoreError.keychainDeleteFailed(deleteStatus)
+        }
 
         var addQuery = query
         addQuery[kSecValueData as String] = data
@@ -84,10 +102,25 @@ public final class CAStore: @unchecked Sendable {
         ]
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            throw CAStoreError.missingPrivateKeyInKeychain
+        }
         guard status == errSecSuccess, let data = result as? Data else {
             throw CAStoreError.keychainReadFailed(status)
         }
         return data
+    }
+
+    private func privateKeyExists() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: false,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        return status == errSecSuccess
     }
 
     private func deletePrivateKey() throws {
@@ -98,7 +131,7 @@ public final class CAStore: @unchecked Sendable {
         ]
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
-            throw CAStoreError.keychainWriteFailed(status)
+            throw CAStoreError.keychainDeleteFailed(status)
         }
     }
 }

--- a/macos/Sources/ReverseAPIProxy/CA/CAStore.swift
+++ b/macos/Sources/ReverseAPIProxy/CA/CAStore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Crypto
+import X509
+import SwiftASN1
+import Security
+
+public enum CAStoreError: Error {
+    case missingCertificateOnDisk
+    case keychainWriteFailed(OSStatus)
+    case keychainReadFailed(OSStatus)
+    case invalidStoredPrivateKey
+}
+
+public final class CAStore: @unchecked Sendable {
+    public let directory: URL
+    public let certificateURL: URL
+
+    private let keychainService = "app.reverseapi"
+    private let keychainAccount = "ca.root-private-key"
+
+    public init(applicationSupportURL: URL) throws {
+        let root = applicationSupportURL.appendingPathComponent("ReverseAPI", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        self.directory = root
+        self.certificateURL = root.appendingPathComponent("root.cer")
+    }
+
+    public func loadOrCreate() throws -> RootCertificate {
+        if let existing = try? load() { return existing }
+        return try createAndStore()
+    }
+
+    public func load() throws -> RootCertificate {
+        let derBytes = try Data(contentsOf: certificateURL)
+        let certificate = try Certificate(derEncoded: Array(derBytes))
+        let pemData = try loadPrivateKeyPEM()
+        guard let pemString = String(data: pemData, encoding: .utf8) else {
+            throw CAStoreError.invalidStoredPrivateKey
+        }
+        let privateKey = try Certificate.PrivateKey(pemEncoded: pemString)
+        return RootCertificate(certificate: certificate, privateKey: privateKey)
+    }
+
+    public func createAndStore() throws -> RootCertificate {
+        let root = try CertificateAuthority.generateRoot()
+        try Data(try root.derBytes()).write(to: certificateURL, options: .atomic)
+        let pem = try root.privateKey.serializeAsPEM().pemString
+        try storePrivateKeyPEM(Data(pem.utf8))
+        return root
+    }
+
+    public func reset() throws {
+        try? FileManager.default.removeItem(at: certificateURL)
+        try deletePrivateKey()
+    }
+
+    public func exists() -> Bool {
+        guard FileManager.default.fileExists(atPath: certificateURL.path) else { return false }
+        return (try? loadPrivateKeyPEM()) != nil
+    }
+
+    private func storePrivateKeyPEM(_ data: Data) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else { throw CAStoreError.keychainWriteFailed(status) }
+    }
+
+    private func loadPrivateKeyPEM() throws -> Data {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw CAStoreError.keychainReadFailed(status)
+        }
+        return data
+    }
+
+    private func deletePrivateKey() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw CAStoreError.keychainWriteFailed(status)
+        }
+    }
+}

--- a/macos/Sources/ReverseAPIProxy/ProxyEngine+Bootstrap.swift
+++ b/macos/Sources/ReverseAPIProxy/ProxyEngine+Bootstrap.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension ProxyEngine {
+    public static func bootstrap(
+        applicationSupportURL: URL,
+        port: Int = 8888,
+        bus: FlowBus = FlowBus()
+    ) throws -> ProxyEngine {
+        let store = try CAStore(applicationSupportURL: applicationSupportURL)
+        let root = try store.loadOrCreate()
+        return try ProxyEngine(root: root, port: port, bus: bus)
+    }
+
+    public func rootDERBytes() throws -> Data {
+        Data(try root.derBytes())
+    }
+
+    public func rootPEM() throws -> String {
+        try root.pem()
+    }
+}

--- a/macos/Sources/ReverseAPIProxy/System/CertificateTrustInstaller.swift
+++ b/macos/Sources/ReverseAPIProxy/System/CertificateTrustInstaller.swift
@@ -45,7 +45,16 @@ public final class CertificateTrustInstaller: Sendable {
         guard let cert = try? secCertificate(from: derBytes) else { return false }
         var settings: CFArray?
         let status = SecTrustSettingsCopyTrustSettings(cert, .user, &settings)
-        return status == errSecSuccess
+        guard status == errSecSuccess, let array = settings as? [[String: Any]] else {
+            return false
+        }
+        for entry in array {
+            if let raw = entry[kSecTrustSettingsResult as String] as? Int,
+               raw == Int(SecTrustSettingsResult.trustRoot.rawValue) {
+                return true
+            }
+        }
+        return false
     }
 
     private func secCertificate(from derBytes: Data) throws -> SecCertificate {

--- a/macos/Sources/ReverseAPIProxy/System/CertificateTrustInstaller.swift
+++ b/macos/Sources/ReverseAPIProxy/System/CertificateTrustInstaller.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Security
+
+public enum CertificateTrustError: Error {
+    case invalidCertificate
+    case addFailed(OSStatus)
+    case trustFailed(OSStatus)
+}
+
+public final class CertificateTrustInstaller: Sendable {
+    public init() {}
+
+    public func install(derBytes: Data) throws {
+        let cert = try secCertificate(from: derBytes)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassCertificate,
+            kSecValueRef as String: cert,
+        ]
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status != errSecSuccess && status != errSecDuplicateItem {
+            throw CertificateTrustError.addFailed(status)
+        }
+
+        let trustSettings: [[String: Any]] = [[
+            kSecTrustSettingsResult as String: SecTrustSettingsResult.trustRoot.rawValue
+        ]]
+        let trustStatus = SecTrustSettingsSetTrustSettings(cert, .user, trustSettings as CFArray)
+        guard trustStatus == errSecSuccess else {
+            throw CertificateTrustError.trustFailed(trustStatus)
+        }
+    }
+
+    public func uninstall(derBytes: Data) throws {
+        let cert = try secCertificate(from: derBytes)
+        SecTrustSettingsRemoveTrustSettings(cert, .user)
+        let removeQuery: [String: Any] = [
+            kSecClass as String: kSecClassCertificate,
+            kSecValueRef as String: cert,
+        ]
+        SecItemDelete(removeQuery as CFDictionary)
+    }
+
+    public func isInstalled(derBytes: Data) -> Bool {
+        guard let cert = try? secCertificate(from: derBytes) else { return false }
+        var settings: CFArray?
+        let status = SecTrustSettingsCopyTrustSettings(cert, .user, &settings)
+        return status == errSecSuccess
+    }
+
+    private func secCertificate(from derBytes: Data) throws -> SecCertificate {
+        guard let cert = SecCertificateCreateWithData(nil, derBytes as CFData) else {
+            throw CertificateTrustError.invalidCertificate
+        }
+        return cert
+    }
+}

--- a/macos/Sources/ReverseAPIProxy/System/SystemProxyController.swift
+++ b/macos/Sources/ReverseAPIProxy/System/SystemProxyController.swift
@@ -4,6 +4,18 @@ public enum SystemProxyError: Error {
     case scriptFailed(String)
     case networksetupFailed(Int32, String)
     case noNetworkServices
+    case invalidHost(String)
+    case invalidPort(Int)
+}
+
+public struct ProxyServiceSnapshot: Sendable, Equatable {
+    public let service: String
+    public let httpEnabled: Bool
+    public let httpHost: String
+    public let httpPort: Int
+    public let httpsEnabled: Bool
+    public let httpsHost: String
+    public let httpsPort: Int
 }
 
 public final class SystemProxyController: @unchecked Sendable {
@@ -12,15 +24,17 @@ public final class SystemProxyController: @unchecked Sendable {
     public init() {}
 
     public func enable(host: String, port: Int) throws {
+        try validate(host: host, port: port)
         let services = try listNetworkServices()
         guard !services.isEmpty else { throw SystemProxyError.noNetworkServices }
+        let quotedHost = shellQuote(host)
         let commands = services.flatMap { service -> [String] in
-            let q = shellQuote(service)
+            let quotedService = shellQuote(service)
             return [
-                "\(networksetup) -setwebproxy \(q) \(host) \(port)",
-                "\(networksetup) -setsecurewebproxy \(q) \(host) \(port)",
-                "\(networksetup) -setwebproxystate \(q) on",
-                "\(networksetup) -setsecurewebproxystate \(q) on",
+                "\(networksetup) -setwebproxy \(quotedService) \(quotedHost) \(port)",
+                "\(networksetup) -setsecurewebproxy \(quotedService) \(quotedHost) \(port)",
+                "\(networksetup) -setwebproxystate \(quotedService) on",
+                "\(networksetup) -setsecurewebproxystate \(quotedService) on",
             ]
         }
         try runWithAdminPrivileges(commands.joined(separator: " && "))
@@ -39,11 +53,51 @@ public final class SystemProxyController: @unchecked Sendable {
         try runWithAdminPrivileges(commands.joined(separator: " && "))
     }
 
+    public func restore(_ snapshots: [ProxyServiceSnapshot]) throws {
+        var commands: [String] = []
+        for snapshot in snapshots {
+            let q = shellQuote(snapshot.service)
+            commands.append(
+                "\(networksetup) -setwebproxy \(q) \(shellQuote(snapshot.httpHost)) \(snapshot.httpPort)"
+            )
+            commands.append(
+                "\(networksetup) -setsecurewebproxy \(q) \(shellQuote(snapshot.httpsHost)) \(snapshot.httpsPort)"
+            )
+            commands.append(
+                "\(networksetup) -setwebproxystate \(q) \(snapshot.httpEnabled ? "on" : "off")"
+            )
+            commands.append(
+                "\(networksetup) -setsecurewebproxystate \(q) \(snapshot.httpsEnabled ? "on" : "off")"
+            )
+        }
+        guard !commands.isEmpty else { return }
+        try runWithAdminPrivileges(commands.joined(separator: " && "))
+    }
+
+    public func snapshot() throws -> [ProxyServiceSnapshot] {
+        try listNetworkServices().map { service in
+            let http = try parseGetWebProxy(service: service, command: "-getwebproxy")
+            let https = try parseGetWebProxy(service: service, command: "-getsecurewebproxy")
+            return ProxyServiceSnapshot(
+                service: service,
+                httpEnabled: http.enabled,
+                httpHost: http.host,
+                httpPort: http.port,
+                httpsEnabled: https.enabled,
+                httpsHost: https.host,
+                httpsPort: https.port
+            )
+        }
+    }
+
     public func isEnabled() throws -> Bool {
         let services = try listNetworkServices()
         for service in services {
-            let output = try shell(networksetup, "-getwebproxy", service)
-            if output.contains("Enabled: Yes") { return true }
+            let http = try shell(networksetup, "-getwebproxy", service)
+            let https = try shell(networksetup, "-getsecurewebproxy", service)
+            if http.contains("Enabled: Yes") && https.contains("Enabled: Yes") {
+                return true
+            }
         }
         return false
     }
@@ -59,6 +113,42 @@ public final class SystemProxyController: @unchecked Sendable {
                 if line.hasPrefix("*") { return false }
                 return true
             }
+    }
+
+    internal struct GetWebProxyResult {
+        let enabled: Bool
+        let host: String
+        let port: Int
+    }
+
+    internal static func parse(getWebProxyOutput output: String) -> GetWebProxyResult {
+        var enabled = false
+        var host = ""
+        var port = 0
+        for line in output.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("Enabled:") {
+                enabled = trimmed.contains("Yes")
+            } else if trimmed.hasPrefix("Server:") {
+                host = String(trimmed.dropFirst("Server:".count)).trimmingCharacters(in: .whitespaces)
+            } else if trimmed.hasPrefix("Port:") {
+                port = Int(trimmed.dropFirst("Port:".count).trimmingCharacters(in: .whitespaces)) ?? 0
+            }
+        }
+        return GetWebProxyResult(enabled: enabled, host: host, port: port)
+    }
+
+    private func parseGetWebProxy(service: String, command: String) throws -> GetWebProxyResult {
+        let output = try shell(networksetup, command, service)
+        return Self.parse(getWebProxyOutput: output)
+    }
+
+    private func validate(host: String, port: Int) throws {
+        guard HostPort.validPortRange.contains(port) else { throw SystemProxyError.invalidPort(port) }
+        let forbidden = CharacterSet(charactersIn: " \t\n\r'\"`\\$;&|<>")
+        if host.rangeOfCharacter(from: forbidden) != nil || host.isEmpty {
+            throw SystemProxyError.invalidHost(host)
+        }
     }
 
     @discardableResult
@@ -99,7 +189,7 @@ public final class SystemProxyController: @unchecked Sendable {
         }
     }
 
-    private func shellQuote(_ value: String) -> String {
+    internal func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/macos/Sources/ReverseAPIProxy/System/SystemProxyController.swift
+++ b/macos/Sources/ReverseAPIProxy/System/SystemProxyController.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+public enum SystemProxyError: Error {
+    case scriptFailed(String)
+    case networksetupFailed(Int32, String)
+    case noNetworkServices
+}
+
+public final class SystemProxyController: @unchecked Sendable {
+    private let networksetup = "/usr/sbin/networksetup"
+
+    public init() {}
+
+    public func enable(host: String, port: Int) throws {
+        let services = try listNetworkServices()
+        guard !services.isEmpty else { throw SystemProxyError.noNetworkServices }
+        let commands = services.flatMap { service -> [String] in
+            let q = shellQuote(service)
+            return [
+                "\(networksetup) -setwebproxy \(q) \(host) \(port)",
+                "\(networksetup) -setsecurewebproxy \(q) \(host) \(port)",
+                "\(networksetup) -setwebproxystate \(q) on",
+                "\(networksetup) -setsecurewebproxystate \(q) on",
+            ]
+        }
+        try runWithAdminPrivileges(commands.joined(separator: " && "))
+    }
+
+    public func disable() throws {
+        let services = try listNetworkServices()
+        guard !services.isEmpty else { return }
+        let commands = services.flatMap { service -> [String] in
+            let q = shellQuote(service)
+            return [
+                "\(networksetup) -setwebproxystate \(q) off",
+                "\(networksetup) -setsecurewebproxystate \(q) off",
+            ]
+        }
+        try runWithAdminPrivileges(commands.joined(separator: " && "))
+    }
+
+    public func isEnabled() throws -> Bool {
+        let services = try listNetworkServices()
+        for service in services {
+            let output = try shell(networksetup, "-getwebproxy", service)
+            if output.contains("Enabled: Yes") { return true }
+        }
+        return false
+    }
+
+    public func listNetworkServices() throws -> [String] {
+        let output = try shell(networksetup, "-listallnetworkservices")
+        return output
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .filter { line in
+                guard !line.isEmpty else { return false }
+                if line.hasPrefix("An asterisk") { return false }
+                if line.hasPrefix("*") { return false }
+                return true
+            }
+    }
+
+    @discardableResult
+    private func shell(_ executable: String, _ arguments: String...) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        process.waitUntilExit()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let stdout = String(decoding: outData, as: UTF8.self)
+        let stderr = String(decoding: errData, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw SystemProxyError.networksetupFailed(process.terminationStatus, stderr.isEmpty ? stdout : stderr)
+        }
+        return stdout
+    }
+
+    private func runWithAdminPrivileges(_ command: String) throws {
+        let escaped = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = "do shell script \"\(escaped)\" with administrator privileges"
+        var error: NSDictionary?
+        if let apple = NSAppleScript(source: script) {
+            apple.executeAndReturnError(&error)
+        } else {
+            throw SystemProxyError.scriptFailed("failed to construct script")
+        }
+        if let error {
+            let message = error[NSAppleScript.errorMessage] as? String ?? "\(error)"
+            throw SystemProxyError.scriptFailed(message)
+        }
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/macos/Tests/ReverseAPIProxyTests/SystemProxyControllerTests.swift
+++ b/macos/Tests/ReverseAPIProxyTests/SystemProxyControllerTests.swift
@@ -50,19 +50,32 @@ final class SystemProxyControllerTests: XCTestCase {
 
     func testEnableRejectsHostWithShellMetacharacters() {
         let controller = SystemProxyController()
-        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1; rm -rf /", port: 8888))
-        XCTAssertThrowsError(try controller.enable(host: "$(whoami)", port: 8888))
-        XCTAssertThrowsError(try controller.enable(host: "a b", port: 8888))
+        for bad in ["127.0.0.1; rm -rf /", "$(whoami)", "a b"] {
+            XCTAssertThrowsError(try controller.enable(host: bad, port: 8888)) { error in
+                guard case SystemProxyError.invalidHost = error else {
+                    XCTFail("expected invalidHost, got \(error)"); return
+                }
+            }
+        }
     }
 
     func testEnableRejectsInvalidPort() {
         let controller = SystemProxyController()
-        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1", port: 0))
-        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1", port: 70000))
+        for bad in [0, 70000] {
+            XCTAssertThrowsError(try controller.enable(host: "127.0.0.1", port: bad)) { error in
+                guard case SystemProxyError.invalidPort = error else {
+                    XCTFail("expected invalidPort, got \(error)"); return
+                }
+            }
+        }
     }
 
     func testEnableRejectsEmptyHost() {
         let controller = SystemProxyController()
-        XCTAssertThrowsError(try controller.enable(host: "", port: 8888))
+        XCTAssertThrowsError(try controller.enable(host: "", port: 8888)) { error in
+            guard case SystemProxyError.invalidHost = error else {
+                XCTFail("expected invalidHost, got \(error)"); return
+            }
+        }
     }
 }

--- a/macos/Tests/ReverseAPIProxyTests/SystemProxyControllerTests.swift
+++ b/macos/Tests/ReverseAPIProxyTests/SystemProxyControllerTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import ReverseAPIProxy
+
+final class SystemProxyControllerTests: XCTestCase {
+    func testShellQuoteEscapesSingleQuotes() {
+        let controller = SystemProxyController()
+        XCTAssertEqual(controller.shellQuote("plain"), "'plain'")
+        XCTAssertEqual(controller.shellQuote("o'brien"), "'o'\\''brien'")
+    }
+
+    func testShellQuoteHandlesShellMetacharacters() {
+        let controller = SystemProxyController()
+        XCTAssertEqual(controller.shellQuote("a; rm -rf /"), "'a; rm -rf /'")
+        XCTAssertEqual(controller.shellQuote("foo && bar"), "'foo && bar'")
+    }
+
+    func testParseGetWebProxyEnabled() {
+        let output = """
+        Enabled: Yes
+        Server: 127.0.0.1
+        Port: 8888
+        Authenticated Proxy Enabled: 0
+        """
+        let result = SystemProxyController.parse(getWebProxyOutput: output)
+        XCTAssertTrue(result.enabled)
+        XCTAssertEqual(result.host, "127.0.0.1")
+        XCTAssertEqual(result.port, 8888)
+    }
+
+    func testParseGetWebProxyDisabled() {
+        let output = """
+        Enabled: No
+        Server:
+        Port: 0
+        Authenticated Proxy Enabled: 0
+        """
+        let result = SystemProxyController.parse(getWebProxyOutput: output)
+        XCTAssertFalse(result.enabled)
+        XCTAssertEqual(result.host, "")
+        XCTAssertEqual(result.port, 0)
+    }
+
+    func testParseGetWebProxyHandlesExtraWhitespace() {
+        let output = "  Enabled: Yes  \n   Server:    proxy.example.com  \n   Port:   3128"
+        let result = SystemProxyController.parse(getWebProxyOutput: output)
+        XCTAssertTrue(result.enabled)
+        XCTAssertEqual(result.host, "proxy.example.com")
+        XCTAssertEqual(result.port, 3128)
+    }
+
+    func testEnableRejectsHostWithShellMetacharacters() {
+        let controller = SystemProxyController()
+        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1; rm -rf /", port: 8888))
+        XCTAssertThrowsError(try controller.enable(host: "$(whoami)", port: 8888))
+        XCTAssertThrowsError(try controller.enable(host: "a b", port: 8888))
+    }
+
+    func testEnableRejectsInvalidPort() {
+        let controller = SystemProxyController()
+        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1", port: 0))
+        XCTAssertThrowsError(try controller.enable(host: "127.0.0.1", port: 70000))
+    }
+
+    func testEnableRejectsEmptyHost() {
+        let controller = SystemProxyController()
+        XCTAssertThrowsError(try controller.enable(host: "", port: 8888))
+    }
+}


### PR DESCRIPTION
Stacked on top of #72.

## What's in
- **CAStore** — persists root cert under Application Support, private key as PEM in the user Keychain (generic password). `loadOrCreate` / `reset`.
- **CertificateTrustInstaller** — SecItemAdd + SecTrustSettingsSetTrustSettings on `.user`. First call triggers the system password prompt.
- **SystemProxyController** — `networksetup -listallnetworkservices`, then toggles HTTP + HTTPS proxy on every enabled service. Admin escalation via `NSAppleScript` `do shell script … with administrator privileges`.
- **ProxyEngine.bootstrap(applicationSupportURL:)** — factory wiring.
- **rae-proxy CLI** — `--install-ca-trust`, `--enable-system-proxy`, `--reset-ca`, signal-driven cleanup.

## How to try
```
swift run rae-proxy --install-ca-trust --enable-system-proxy
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTPjy1wN5q81VJHDcJBxVt)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent root CA storage, user-level Keychain trust, and an admin-elevated macOS system proxy toggle. Improves safety with pre-enable snapshots, rollback on failure, and cleanup that restores the prior proxy state.

- **New Features**
  - `CAStore`: persists root cert (Application Support) and private key (Keychain); load/create/reset.
  - `CertificateTrustInstaller`: install/uninstall user trust; `isInstalled` checks for `trustRoot`.
  - `SystemProxyController`: toggles HTTP/HTTPS on all services with admin escalation; `snapshot()`/`restore()`; `isEnabled` requires both.
  - `ProxyEngine.bootstrap(...)`: factory wiring plus root DER/PEM helpers.
  - `rae-proxy` CLI: `--install-ca-trust`, `--enable-system-proxy`, `--reset-ca`; Ctrl-C cleanup restores the captured snapshot.

- **Bug Fixes**
  - Validate and shell-quote proxy host; enforce port range 1–65535.
  - Stop silent CA rotation: `CAStore.loadOrCreate` now throws explicit load errors.
  - `--reset-ca`: uninstall user trust from DER read off disk even if the Keychain key is missing; then delete files.
  - Roll back system proxy and stop the engine if enable fails; fix signal handler race by ignoring the default handler before activation.

<sup>Written for commit 19827161ba3c904be7f7ab436a7c529fa3b27547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces persistent CA storage (`CAStore`), user-level certificate trust installation (`CertificateTrustInstaller`), and a system proxy toggle (`SystemProxyController`) with admin escalation via AppleScript, wired together through `ProxyEngine.bootstrap` and a new `rae-proxy` CLI.

- **CAStore** persists the root cert to Application Support and the private key as PEM in the user Keychain; `loadOrCreate` now throws on load failure rather than silently rotating the CA.
- **CertificateTrustInstaller** uses `SecTrustSettingsSetTrustSettings` on the `.user` domain, and `isInstalled` correctly inspects the returned `CFArray` for a `trustRoot` entry.
- **SystemProxyController** validates and shell-quotes all inputs before building admin-escalated `networksetup` commands.
- **`--reset-ca` trust uninstall** is gated on `store.exists()`, which silently skips the `uninstall` call whenever the cert file is present but the keychain item is missing.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; one defect in the --reset-ca path can leave an orphaned trusted CA in the user trust store when the keychain item has been independently removed.

The --reset-ca path gates the trust-uninstall call on store.exists(), which requires both the cert file and the keychain item to be present. If the keychain item is gone, the uninstall is skipped and the old CA remains trusted indefinitely after reset.

macos/Sources/rae-proxy/main.swift — the --reset-ca block at lines 17-28

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| macos/Sources/rae-proxy/main.swift | CLI wiring for all new features; trust-uninstall in --reset-ca path is gated on store.exists() which silently skips the call when the keychain item is absent |
| macos/Sources/ReverseAPIProxy/CA/CAStore.swift | New persistence layer for root CA; loadOrCreate now properly throws on load failure instead of silently rotating; keychain access pattern looks correct |
| macos/Sources/ReverseAPIProxy/System/CertificateTrustInstaller.swift | isInstalled correctly inspects the CFArray for a trustRoot entry; install/uninstall use Security framework correctly |
| macos/Sources/ReverseAPIProxy/System/SystemProxyController.swift | Host/port validation and shell-quoting in enable() look correct; snapshot/restore/disable implementations are clean |
| macos/Sources/ReverseAPIProxy/ProxyEngine+Bootstrap.swift | Thin factory extension wiring CAStore into ProxyEngine; no issues |
| macos/Tests/ReverseAPIProxyTests/SystemProxyControllerTests.swift | Unit tests cover shellQuote escaping, proxy output parsing, and input validation; good coverage of the pure-logic paths |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
macos/Sources/rae-proxy/main.swift:17-26
When the keychain item is missing but the cert file still exists, `store.exists()` returns `false` (it requires both to be present), so the entire trust-uninstall block is skipped. `store.reset()` then removes the cert file, leaving the old CA permanently installed in the user trust store with no backing files. Subsequent `--install-ca-trust` runs add a new cert alongside the orphaned trusted one. Uninstalling trust only needs the DER bytes from the cert file — not the private key — so reading `certificateURL` directly sidesteps this gap.

```suggestion
            if args.contains("--reset-ca") {
                if FileManager.default.fileExists(atPath: store.certificateURL.path),
                   let existingDER = try? Data(contentsOf: store.certificateURL) {
                    if installer.isInstalled(derBytes: existingDER) {
                        try installer.uninstall(derBytes: existingDER)
                    }
                }
                try store.reset()
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["M2 review fixes + tests"](https://github.com/kalil0321/reverse-api-engineer/commit/fbf9bd78f8d7700a8717a9ce8b72705bdaf00736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32744313)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->