### PR TITLE
docs: clarify Cursor SDK agent browser (MCP subprocess vs IDE Browser Tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Agent mode providers:
 - **auto** (default): Playwright MCP, single workflow for browsing + reverse engineering.
 - **chrome-mcp**: drives your real Chrome so you keep existing sessions/cookies. Requires Chrome 146+ and Node.js 20.19+.
 
+With **`sdk: "cursor"`**, agent mode still uses the **same** stdio MCP processes (`rae-playwright-mcp` or `chrome-devtools-mcp`) started by the Cursor Agent API bridge—not Cursor Desktop’s built-in “Browser Tab” tools. Expect the usual agent requirements: **`CURSOR_API_KEY`**, Node.js with **`npx`**, Playwright/Chromium setup for **`auto`**, and Chrome remote debugging / headless Chrome for **`chrome-mcp`** as above.
+
 ## Configuration
 
 Settings live in `~/.reverse-api/config.json` and can be edited via `/settings` in the CLI:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Kalil asked what we could do regarding **support for agent browser** in context of the Cursor integration. Without the Cursor-only PR thread body, two things are actionable in-repo:

1. **Product clarification** — `sdk: "cursor"` agent mode launches the same **stdio** Playwright MCP / Chrome DevTools MCP stacks as other SDKs, via `@cursor/sdk` + the Node bridge. It does **not** attach to Cursor Desktop’s built-in Browser Tab MCP. This README note should reduce confusion for reviewers and users.

## What Cursor Cloud Agent can still help with elsewhere

- **Implementation**: MCP configs, prompts (`user_playwright.md` / `user_chrome_mcp.md`), dry-run checks, Cursor bridge (`run.mjs`), error messages.
- **Verification**: Extend tests around multi-turn `CursorAutoEngineer` if we want stronger regression coverage beyond PR #71.
- **Out of scope for this repo**: Bugs in Cursor Desktop Browser Automation (`cursor-ide-browser`); those need Cursor IDE updates / support.

## Testing

Documentation-only change; no code paths modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e7eb3ff-61a2-42ec-8bd1-9624a2b49285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e7eb3ff-61a2-42ec-8bd1-9624a2b49285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified that `sdk: "cursor"` agent mode uses the same stdio MCP subprocesses (`rae-playwright-mcp` or `chrome-devtools-mcp`) via the Cursor Agent API bridge, not Cursor Desktop’s Browser Tab MCP. Also noted required setup: `CURSOR_API_KEY`, Node.js with `npx`, Playwright/Chromium for `auto`, and Chrome remote debugging for `chrome-mcp`.

<sup>Written for commit 00695a82f7061ce43e29e8d670d434f2935b99dc. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

