### PR TITLE
Non-interactive AskUserQuestion auto-reply and --json-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Settings live in `~/.reverse-api/config.json` and can be edited via `/settings` 
   "opencode_model": "claude-sonnet-4-6",
   "opencode_provider": "anthropic",
   "copilot_model": "gpt-5",
-  "cursor_model": "composer-2",
+  "cursor_model": "composer-2.5",
   "output_dir": null,
   "output_language": "python",
   "real_time_sync": true,

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -108,7 +108,7 @@ class ClaudeAutoEngineer(ClaudeEngineer):
         """Handle tool permission requests, with interactive UI for AskUserQuestion."""
         if tool_name == "AskUserQuestion":
             questions = input_data.get("questions", [])
-            answers = await self._ask_user_interactive(questions)
+            answers = await self._ask_user_questions(questions)
             return PermissionResultAllow(
                 updated_input={"questions": questions, "answers": answers},
             )

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -18,6 +18,13 @@ DEBUG = os.environ.get("DEBUG", "0") == "1"
 
 OTHER_OPTION = "Other (type your answer)"
 
+NON_INTERACTIVE_ASK_USER_MESSAGE = (
+    "The user is running the CLI in non-interactive mode and cannot answer. "
+    "Assume the best reasonable answer from context and continue. "
+    "If you truly cannot proceed without a human choice, stop and instruct the caller "
+    "to start a new session with a clearer, more specific prompt."
+)
+
 
 class BaseEngineer(ABC):
     """Abstract base class for API reverse engineering implementations."""
@@ -72,6 +79,19 @@ class BaseEngineer(ABC):
         # conversation loop in subclasses ends after the first generation.
         # Set this from --json / --no-interactive entry points.
         self.interactive = interactive
+        self._json_event_sink: Any = None
+
+    def _emit_json_event(self, event: dict[str, Any]) -> None:
+        sink = self._json_event_sink
+        if sink:
+            sink(event)
+
+    @staticmethod
+    def _is_ask_user_tool_name(tool_name: str) -> bool:
+        n = tool_name.lower().replace("-", "_")
+        if n == "askuserquestion":
+            return True
+        return "ask" in n and "user" in n and "question" in n
 
     def _handle_cli_stderr(self, line: str) -> None:
         """Filter CLI subprocess stderr. Shows full output in DEBUG mode, otherwise shows a single clean error."""
@@ -146,6 +166,25 @@ class BaseEngineer(ABC):
         if self.sync_watcher:
             return self.sync_watcher.get_status()
         return None
+
+    async def _ask_user_questions(self, questions: list[dict[str, Any]]) -> dict[str, str]:
+        """Resolve AskUserQuestion prompts (interactive UI or non-interactive stub)."""
+        if not self.interactive:
+            answers: dict[str, str] = {}
+            count = 0
+            for q in questions:
+                question_text = q.get("question", "") if isinstance(q, dict) else getattr(q, "question", "")
+                if not question_text:
+                    continue
+                answers[question_text] = NON_INTERACTIVE_ASK_USER_MESSAGE
+                count += 1
+            if count:
+                self.ui.console.print(
+                    f"  [dim]AskUserQuestion skipped ({count} question(s); non-interactive mode)[/dim]"
+                )
+                self._emit_json_event({"event": "ask_user_skipped", "count": count})
+            return answers
+        return await self._ask_user_interactive(questions)
 
     async def _ask_user_interactive(self, questions: list[dict[str, Any]]) -> dict[str, str]:
         """Prompt the user interactively for answers to questions.

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -64,7 +64,7 @@ def default_model_for_configured_sdk(sdk: str | None = None) -> str:
     if s == "copilot":
         return config_manager.get("copilot_model", "gpt-5")
     if s == "cursor":
-        return config_manager.get("cursor_model", "composer-2")
+        return config_manager.get("cursor_model", "composer-2.5")
     return config_manager.get("claude_code_model", "claude-sonnet-4-6")
 
 
@@ -187,6 +187,13 @@ def _quiet_consoles_for_json():
         sys.stdout = real_stdout
         for c, original_inner in redirected_consoles:
             c._file = original_inner
+
+
+def _write_json_stdout(real_stdout, payload: dict, *, json_stream: bool) -> None:
+    """Write final CLI JSON payload (single doc or NDJSON terminal event)."""
+    out = {"event": "result", **payload} if json_stream else payload
+    real_stdout.write(json.dumps(out) + "\n")
+    real_stdout.flush()
 
 
 def _build_dry_run_payload(
@@ -346,7 +353,7 @@ def _build_dry_run_payload(
         "claude": "claude-sonnet-4-6",
         "opencode": "claude-opus-4-6",
         "copilot": "gpt-5",
-        "cursor": "composer-2",
+        "cursor": "composer-2.5",
     }.get(sdk, "claude-sonnet-4-6")
     resolved_model = model or config_manager.get(sdk_model_key, sdk_default_model)
 
@@ -1084,11 +1091,11 @@ def handle_settings(mode_color=THEME_PRIMARY):
                 console.print(f" [dim]updated[/dim] copilot model: {new_model}\n")
 
     elif action == "cursor_model":
-        current = config_manager.get("cursor_model", "composer-2")
+        current = config_manager.get("cursor_model", "composer-2.5")
         new_model = questionary.text(
             " > cursor model",
-            default=current or "composer-2",
-            instruction="(e.g., 'composer-2', 'auto' — see Cursor SDK docs)",
+            default=current or "composer-2.5",
+            instruction="(e.g., 'composer-2.5', 'composer-2' — see Cursor SDK docs)",
             qmark="",
             style=questionary.Style(
                 [
@@ -1457,6 +1464,12 @@ Exit codes:
     help="Emit a single JSON result on stdout (logs go to stderr). Implies --no-interactive.",
 )
 @click.option(
+    "--json-stream",
+    "json_stream",
+    is_flag=True,
+    help="Emit NDJSON progress events on stdout during the run, then a final {\"event\":\"result\",...} line. Implies --no-interactive.",
+)
+@click.option(
     "--headless",
     is_flag=True,
     help="Launch the MCP-controlled browser in headless mode (required on machines without an X server). For chrome-mcp this drops --autoConnect since auto-connect requires a headed Chrome instance.",
@@ -1466,7 +1479,7 @@ Exit codes:
     is_flag=True,
     help="Validate prompt/url/config/env without launching the browser. Emits a manifest of what would run + check results. Implies --json. Exits 0 if all checks pass, 1 if any error.",
 )
-def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry_run):
+def agent(prompt, url, model, output_dir, no_interactive, as_json, json_stream, headless, dry_run):
     """Run autonomous agent browser session.
 
     Agent mode runs an integrated capture + reverse-engineering pipeline; if you
@@ -1483,10 +1496,11 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
         real_stdout.flush()
         sys.exit(0 if payload["status"] == "ok" else 1)
 
-    no_interactive = no_interactive or as_json
+    no_interactive = no_interactive or as_json or json_stream
+    machine_output = as_json or json_stream
 
     if no_interactive and not (prompt and prompt.strip()):
-        if as_json:
+        if machine_output:
             misuse = _build_agent_payload(
                 {},
                 prompt=prompt,
@@ -1495,6 +1509,8 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
                 error="--prompt is required in non-interactive/--json mode",
                 error_kind_hint="misuse",
             )
+            if json_stream:
+                misuse = {"event": "result", **misuse}
             click.echo(json.dumps(misuse))
         else:
             click.echo("error: --prompt is required when --no-interactive is set", err=True)
@@ -1502,9 +1518,9 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
 
     # Either flag must suppress the post-generation follow-up prompt that would
     # otherwise block on stdin (`input("  > ")`) inside ClaudeAutoEngineer.
-    interactive = not (as_json or no_interactive)
+    interactive = not no_interactive
 
-    if not as_json:
+    if not machine_output:
         run_agent_capture(
             prompt=prompt,
             url=url,
@@ -1515,8 +1531,15 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
         )
         return
 
+    from .json_stream import make_json_stream_sink
+
     payload: dict
     with _quiet_consoles_for_json() as real_stdout:
+        sink = (
+            make_json_stream_sink(lambda line: (real_stdout.write(line + "\n"), real_stdout.flush()))
+            if json_stream
+            else None
+        )
         try:
             result = run_agent_capture(
                 prompt=prompt,
@@ -1525,6 +1548,7 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
                 output_dir=output_dir,
                 interactive=interactive,
                 headless=headless,
+                json_event_sink=sink,
             )
             payload = _build_agent_payload(result, prompt=prompt, url=url, output_dir=output_dir)
         except KeyboardInterrupt as e:
@@ -1538,8 +1562,7 @@ def agent(prompt, url, model, output_dir, no_interactive, as_json, headless, dry
                 {}, prompt=prompt, url=url, output_dir=output_dir, error=e
             )
 
-    real_stdout.write(json.dumps(payload) + "\n")
-    real_stdout.flush()
+        _write_json_stdout(real_stdout, payload, json_stream=json_stream)
     sys.exit(0 if payload["status"] == "ok" else 1)
 
 
@@ -1602,7 +1625,15 @@ def run_manual_capture(prompt=None, url=None, reverse_engineer=True, model=None,
         console.print(f" [dim]>[/dim] [dim]use 'reverse-api-engineer engineer {run_id}' to engineer later[/dim]\n")
 
 
-def run_agent_capture(prompt=None, url=None, model=None, output_dir=None, interactive=True, headless=False):
+def run_agent_capture(
+    prompt=None,
+    url=None,
+    model=None,
+    output_dir=None,
+    interactive=True,
+    headless=False,
+    json_event_sink=None,
+):
     """Shared logic for agent capture mode."""
     output_dir = output_dir or config_manager.get("output_dir")
 
@@ -1628,6 +1659,7 @@ def run_agent_capture(prompt=None, url=None, model=None, output_dir=None, intera
         agent_provider=agent_provider,
         interactive=interactive,
         headless=headless,
+        json_event_sink=json_event_sink,
     )
 
 
@@ -1688,6 +1720,7 @@ def run_auto_capture(
     agent_provider="auto",
     interactive=True,
     headless=False,
+    json_event_sink=None,
 ):
     """Auto mode: LLM-driven browser automation + real-time reverse engineering."""
     output_dir = output_dir or config_manager.get("output_dir")
@@ -1792,7 +1825,7 @@ def run_auto_capture(
                 output_language=output_language,
                 interactive=interactive,
                 headless=headless,
-                cursor_model=model or config_manager.get("cursor_model", "composer-2"),
+                cursor_model=model or config_manager.get("cursor_model", "composer-2.5"),
                 cursor_web_search=bool(config_manager.get("cursor_web_search", True)),
                 cursor_setting_sources=_cursor_src,
             )
@@ -1811,6 +1844,12 @@ def run_auto_capture(
                 interactive=interactive,
                 headless=headless,
             )
+
+        if json_event_sink is not None:
+            from .json_stream import attach_json_stream_to_engineer
+
+            attach_json_stream_to_engineer(engineer, json_event_sink)
+            json_event_sink({"event": "agent_started", "mode": mode_label, "url": url})
 
         # Start sync before analysis
         engineer.start_sync()
@@ -1918,7 +1957,13 @@ Exit codes:
     is_flag=True,
     help="Emit a single JSON result on stdout (logs go to stderr). Implies --no-interactive.",
 )
-def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json):
+@click.option(
+    "--json-stream",
+    "json_stream",
+    is_flag=True,
+    help="Emit NDJSON progress events on stdout during the run, then a final {\"event\":\"result\",...} line. Implies --no-interactive.",
+)
+def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json, json_stream):
     """Run reverse engineering on a previous run."""
     # `run_id` is declared optional at the click level so that wrappers using
     # --json get a JSON misuse payload instead of Click's plain-text "missing
@@ -1946,9 +1991,11 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json):
     additional = prompt if (prompt and not fresh) else None
     # Either flag must suppress the post-generation follow-up prompt that
     # would otherwise block on stdin (`input("  > ")`) inside ClaudeEngineer.
-    interactive = not (as_json or no_interactive)
+    no_interactive = no_interactive or as_json or json_stream
+    interactive = not no_interactive
+    machine_output = as_json or json_stream
 
-    if not as_json:
+    if not machine_output:
         run_engineer(
             run_id,
             prompt=main_prompt,
@@ -1960,8 +2007,15 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json):
         )
         return
 
+    from .json_stream import make_json_stream_sink
+
     payload: dict
     with _quiet_consoles_for_json() as real_stdout:
+        sink = (
+            make_json_stream_sink(lambda line: (real_stdout.write(line + "\n"), real_stdout.flush()))
+            if json_stream
+            else None
+        )
         try:
             result = run_engineer(
                 run_id,
@@ -1971,6 +2025,7 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json):
                 output_dir=output_dir,
                 is_fresh=fresh,
                 interactive=interactive,
+                json_event_sink=sink,
             )
             payload = _build_engineer_payload(result, run_id=run_id, prompt=prompt, fresh=fresh)
         except KeyboardInterrupt as e:
@@ -1983,8 +2038,7 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json):
                 None, run_id=run_id, prompt=prompt, fresh=fresh, error=e
             )
 
-    real_stdout.write(json.dumps(payload) + "\n")
-    real_stdout.flush()
+        _write_json_stdout(real_stdout, payload, json_stream=json_stream)
     sys.exit(0 if payload["status"] == "ok" else 1)
 
 
@@ -1998,6 +2052,7 @@ def run_engineer(
     is_fresh=False,
     output_mode="client",
     interactive=True,
+    json_event_sink=None,
 ):
     """Shared logic for reverse engineering."""
     if not har_path or not prompt:
@@ -2040,6 +2095,7 @@ def run_engineer(
             output_language=output_language,
             output_mode=output_mode,
             interactive=interactive,
+            json_event_sink=json_event_sink,
         )
     elif sdk == "copilot":
         result = run_reverse_engineering(
@@ -2056,11 +2112,12 @@ def run_engineer(
             output_language=output_language,
             output_mode=output_mode,
             interactive=interactive,
+            json_event_sink=json_event_sink,
         )
     elif sdk == "cursor":
         _cs = config_manager.get("cursor_setting_sources")
         _cursor_src = _cs if isinstance(_cs, list) and all(isinstance(x, str) for x in _cs) else None
-        _cm = model or config_manager.get("cursor_model", "composer-2")
+        _cm = model or config_manager.get("cursor_model", "composer-2.5")
         result = run_reverse_engineering(
             run_id=run_id,
             har_path=har_path,
@@ -2077,6 +2134,7 @@ def run_engineer(
             output_language=output_language,
             output_mode=output_mode,
             interactive=interactive,
+            json_event_sink=json_event_sink,
         )
     else:
         result = run_reverse_engineering(
@@ -2092,6 +2150,7 @@ def run_engineer(
             output_language=output_language,
             output_mode=output_mode,
             interactive=interactive,
+            json_event_sink=json_event_sink,
         )
 
     if result:

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -1848,8 +1848,13 @@ def run_auto_capture(
         if json_event_sink is not None:
             from .json_stream import attach_json_stream_to_engineer
 
-            attach_json_stream_to_engineer(engineer, json_event_sink)
-            json_event_sink({"event": "agent_started", "mode": mode_label, "url": url})
+            attach_json_stream_to_engineer(
+                engineer,
+                json_event_sink,
+                mode=mode_label,
+                url=url,
+                command="agent",
+            )
 
         # Start sync before analysis
         engineer.start_sync()
@@ -1970,7 +1975,8 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json, 
     # argument" error. We re-validate inline to preserve the same exit-2 UX
     # for non-JSON invocations.
     if not run_id:
-        if as_json:
+        machine_output = as_json or json_stream
+        if machine_output:
             misuse = _build_engineer_payload(
                 None,
                 run_id="",
@@ -1979,7 +1985,11 @@ def engineer(run_id, prompt, fresh, model, output_dir, no_interactive, as_json, 
                 error="RUN_ID is required",
                 error_kind_hint="misuse",
             )
-            click.echo(json.dumps(misuse))
+            if json_stream:
+                with _quiet_consoles_for_json() as real_stdout:
+                    _write_json_stdout(real_stdout, misuse, json_stream=True)
+            else:
+                click.echo(json.dumps(misuse))
         else:
             click.echo("Usage: reverse-api-engineer engineer [OPTIONS] RUN_ID", err=True)
             click.echo("\nError: Missing argument 'RUN_ID'.", err=True)

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -8,7 +8,7 @@ DEFAULT_CONFIG = {
     "agent_provider": "auto",  # "auto" (Playwright MCP) or "chrome-mcp" (Chrome DevTools MCP)
     "claude_code_model": "claude-sonnet-4-6",
     "collector_model": "claude-sonnet-4-6",  # Model for collector mode
-    "cursor_model": "composer-2",  # Model id for Cursor SDK (see Cursor.models.list())
+    "cursor_model": "composer-2.5",  # Model id for Cursor SDK (see Cursor.models.list())
     # When True, local agents load broader Cursor setting layers (plugins/team) so WebFetch/WebSearch
     # and other IDE tools match Cursor desktop behavior. Set False for minimal "project+user" only.
     "cursor_web_search": True,

--- a/src/reverse_api/copilot_engineer.py
+++ b/src/reverse_api/copilot_engineer.py
@@ -54,7 +54,7 @@ class CopilotEngineer(BaseEngineer):
         async def ask_user_question(params: AskUserParams) -> str:
             # Convert pydantic models to dicts for the shared method
             question_dicts = [q.model_dump() for q in params.questions]
-            answers = await engineer._ask_user_interactive(question_dicts)
+            answers = await engineer._ask_user_questions(question_dicts)
             return "\n".join(f"{k}: {v}" for k, v in answers.items())
 
         return ask_user_question

--- a/src/reverse_api/cursor_bridge/run.mjs
+++ b/src/reverse_api/cursor_bridge/run.mjs
@@ -64,7 +64,7 @@ if (!cwd || typeof cwd !== "string") {
   process.exit(1);
 }
 
-const modelId = input.modelId || "composer-2";
+const modelId = input.modelId || "composer-2.5";
 const mcpServers = input.mcpServers && typeof input.mcpServers === "object" ? input.mcpServers : undefined;
 const resumeAgentId = input.resumeAgentId || null;
 const prompt = input.prompt;

--- a/src/reverse_api/cursor_bridge/run.mjs
+++ b/src/reverse_api/cursor_bridge/run.mjs
@@ -33,6 +33,7 @@ function summarizeEvent(ev) {
         type: t,
         name: ev.name,
         status: ev.status,
+        callId: ev.call_id ?? ev.callId,
         args: ev.args,
         result: ev.status !== "running" ? ev.result : undefined,
       };

--- a/src/reverse_api/cursor_engineer.py
+++ b/src/reverse_api/cursor_engineer.py
@@ -73,7 +73,7 @@ class CursorEngineer(BaseEngineer):
         cursor_setting_sources: list[str] | None = None,
         **kwargs: Any,
     ):
-        cm = cursor_model or model or "composer-2"
+        cm = cursor_model or model or "composer-2.5"
         super().__init__(run_id=run_id, har_path=har_path, prompt=prompt, model=cm, **kwargs)
         self.cursor_model = cm
         self.cursor_web_search = cursor_web_search
@@ -165,6 +165,11 @@ class CursorEngineer(BaseEngineer):
                 self._cursor_flush_narrative()
                 args = self._cursor_coerce_args(event.get("args"))
                 self._cursor_emit_todo_ui(name, args)
+                if not self.interactive and self._is_ask_user_tool_name(name):
+                    self._emit_json_event({"event": "ask_user_skipped", "count": 1, "tool": name})
+                    self.ui.console.print(
+                        f"  [dim]AskUserQuestion skipped ({name}; non-interactive mode)[/dim]"
+                    )
                 self.ui.tool_start(name, args)
                 self.message_store.save_tool_start(name, args)
             else:

--- a/src/reverse_api/cursor_engineer.py
+++ b/src/reverse_api/cursor_engineer.py
@@ -121,6 +121,10 @@ class CursorEngineer(BaseEngineer):
     def _cursor_reset_stream_buffers(self) -> None:
         self._cursor_thinking_acc = ""
         self._cursor_assistant_acc = ""
+        # Each turn is a fresh agent stream; clear announced call IDs so a turn
+        # interrupted before a tool's terminal event can't leave stale IDs that
+        # suppress tool_start on a later turn (and so the set can't grow forever).
+        self._cursor_started_calls.clear()
 
     def _cursor_feed_thinking(self, fragment: str) -> None:
         self._cursor_thinking_acc += fragment

--- a/src/reverse_api/cursor_engineer.py
+++ b/src/reverse_api/cursor_engineer.py
@@ -82,6 +82,10 @@ class CursorEngineer(BaseEngineer):
         self.ui = CursorStreamUI(self, verbose=vb)
         self._cursor_thinking_acc = ""
         self._cursor_assistant_acc = ""
+        # Cursor streams several `tool_call`/running deltas per call as the args
+        # fill in; track which call_ids we've already announced so the UI and
+        # json-stream emit exactly one tool_start per logical call.
+        self._cursor_started_calls: set[str] = set()
 
     @staticmethod
     def _cursor_coerce_args(raw: Any) -> dict[str, Any]:
@@ -161,23 +165,33 @@ class CursorEngineer(BaseEngineer):
         elif et == "tool_call":
             name = str(event.get("name") or "tool")
             status = event.get("status")
+            call_id = event.get("callId") or event.get("call_id")
             if status == "running":
-                self._cursor_flush_narrative()
                 args = self._cursor_coerce_args(event.get("args"))
+                # Live todo board reflects the latest snapshot on every delta;
+                # this is a TUI-only render and never reaches the json-stream.
                 self._cursor_emit_todo_ui(name, args)
+                # Announce the tool exactly once, on the first running delta.
+                if call_id and call_id in self._cursor_started_calls:
+                    return
+                if call_id:
+                    self._cursor_started_calls.add(call_id)
+                self._cursor_flush_narrative()
                 if not self.interactive and self._is_ask_user_tool_name(name):
                     self._emit_json_event({"event": "ask_user_skipped", "count": 1, "tool": name})
                     self.ui.console.print(
                         f"  [dim]AskUserQuestion skipped ({name}; non-interactive mode)[/dim]"
                     )
-                self.ui.tool_start(name, args)
+                self.ui.tool_start(name, args, call_id=call_id)
                 self.message_store.save_tool_start(name, args)
             else:
                 is_err = status == "error"
                 res = event.get("result")
                 out = str(res) if res is not None else None
-                self.ui.tool_result(name, is_err, out)
+                self.ui.tool_result(name, is_err, out, call_id=call_id)
                 self.message_store.save_tool_result(name, is_err, out)
+                if call_id:
+                    self._cursor_started_calls.discard(call_id)
 
     async def _one_turn(  # noqa: C901 - subprocess + NDJSON; splitting obscures control flow
         self,

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -31,7 +31,7 @@ class ClaudeEngineer(BaseEngineer):
         """Handle tool permission requests, with interactive UI for AskUserQuestion."""
         if tool_name == "AskUserQuestion":
             questions = input_data.get("questions", [])
-            answers = await self._ask_user_interactive(questions)
+            answers = await self._ask_user_questions(questions)
             return PermissionResultAllow(
                 updated_input={"questions": questions, "answers": answers},
             )
@@ -218,6 +218,7 @@ def run_reverse_engineering(
     output_language: str = "python",
     output_mode: str = "client",
     interactive: bool = True,
+    json_event_sink: Any = None,
 ) -> dict[str, Any] | None:
     """Run reverse engineering with the specified SDK.
 
@@ -226,7 +227,7 @@ def run_reverse_engineering(
         opencode_provider: Provider ID for OpenCode (e.g., "anthropic")
         opencode_model: Model ID for OpenCode (e.g., "claude-sonnet-4-6")
         copilot_model: Model ID for Copilot (e.g., "gpt-5")
-        cursor_model: Model id for Cursor SDK (e.g., "composer-2")
+        cursor_model: Model id for Cursor SDK (e.g., "composer-2.5")
         cursor_web_search: When True, load extra Cursor setting layers so WebFetch/WebSearch and plugins apply.
         cursor_setting_sources: Optional explicit list (overrides cursor_web_search), e.g. ["project","user","all"].
         enable_sync: Enable real-time file syncing during engineering
@@ -310,6 +311,11 @@ def run_reverse_engineering(
             output_mode=output_mode,
             interactive=interactive,
         )
+
+    if json_event_sink is not None:
+        from .json_stream import attach_json_stream_to_engineer
+
+        attach_json_stream_to_engineer(engineer, json_event_sink)
 
     # Start sync before analysis
     engineer.start_sync()

--- a/src/reverse_api/json_stream.py
+++ b/src/reverse_api/json_stream.py
@@ -45,28 +45,36 @@ class StreamingUIWrapper:
         self._sink({"event": "progress", "message": "analysis_started"})
         self._inner.start_analysis()
 
-    def tool_start(self, tool_name: str, tool_input: dict | Any = None) -> None:
-        summary = None
-        if isinstance(tool_input, dict):
-            summary = str(tool_input)[:200] if tool_input else None
-        self._sink(
-            {
-                "event": "tool_start",
-                "name": tool_name,
-                "input_summary": summary,
-            }
-        )
+    def tool_start(
+        self, tool_name: str, tool_input: dict | Any = None, call_id: str | None = None
+    ) -> None:
+        event: dict[str, Any] = {"event": "tool_start", "name": tool_name}
+        if call_id:
+            event["call_id"] = call_id
+        # Emit the real structured input (json.dumps serializes it); a stringified
+        # repr would not be parseable as JSON by downstream consumers.
+        if tool_input is not None:
+            event["input"] = tool_input
+        self._sink(event)
+        # Inner UIs render only; not all accept call_id, so don't forward it.
         self._inner.tool_start(tool_name, tool_input)
 
-    def tool_result(self, tool_name: str, is_error: bool = False, output: str | None = None) -> None:
-        self._sink(
-            {
-                "event": "tool_end",
-                "name": tool_name,
-                "is_error": is_error,
-                "output_preview": (output[:200] if output else None),
-            }
-        )
+    def tool_result(
+        self,
+        tool_name: str,
+        is_error: bool = False,
+        output: str | None = None,
+        call_id: str | None = None,
+    ) -> None:
+        event: dict[str, Any] = {
+            "event": "tool_end",
+            "name": tool_name,
+            "is_error": is_error,
+            "output_preview": (output[:200] if output else None),
+        }
+        if call_id:
+            event["call_id"] = call_id
+        self._sink(event)
         self._inner.tool_result(tool_name, is_error, output)
 
     def thinking(self, text: str, max_length: int = 500) -> None:

--- a/src/reverse_api/json_stream.py
+++ b/src/reverse_api/json_stream.py
@@ -1,0 +1,108 @@
+"""NDJSON event streaming for scripted CLI invocations (--json-stream)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def make_json_stream_sink(write_line: Callable[[str], None]) -> Callable[[dict[str, Any]], None]:
+    """Build a sink that writes one JSON object per line."""
+
+    import json
+
+    def sink(event: dict[str, Any]) -> None:
+        write_line(json.dumps(event, default=str))
+
+    return sink
+
+
+class StreamingUIWrapper:
+    """Delegate to an inner UI and emit json-stream events for key lifecycle hooks."""
+
+    def __init__(self, inner: Any, sink: Callable[[dict[str, Any]], None]) -> None:
+        self._inner = inner
+        self._sink = sink
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def header(self, run_id: str, prompt: str, model: str | None = None, sdk: str | None = None, mode: str | None = None) -> None:
+        self._sink(
+            {
+                "event": "header",
+                "run_id": run_id,
+                "prompt": prompt,
+                "model": model,
+                "sdk": sdk,
+                "mode": mode,
+            }
+        )
+        self._inner.header(run_id, prompt, model=model, sdk=sdk, mode=mode)
+
+    def start_analysis(self) -> None:
+        self._sink({"event": "progress", "message": "analysis_started"})
+        self._inner.start_analysis()
+
+    def tool_start(self, tool_name: str, tool_input: dict | Any = None) -> None:
+        summary = None
+        if isinstance(tool_input, dict):
+            summary = str(tool_input)[:200] if tool_input else None
+        self._sink(
+            {
+                "event": "tool_start",
+                "name": tool_name,
+                "input_summary": summary,
+            }
+        )
+        self._inner.tool_start(tool_name, tool_input)
+
+    def tool_result(self, tool_name: str, is_error: bool = False, output: str | None = None) -> None:
+        self._sink(
+            {
+                "event": "tool_end",
+                "name": tool_name,
+                "is_error": is_error,
+                "output_preview": (output[:200] if output else None),
+            }
+        )
+        self._inner.tool_result(tool_name, is_error, output)
+
+    def thinking(self, text: str, max_length: int = 500) -> None:
+        preview = text[:500] if text else ""
+        if preview.strip():
+            self._sink({"event": "thinking", "text": preview})
+        if hasattr(self._inner, "thinking"):
+            try:
+                self._inner.thinking(text, max_length=max_length)
+            except TypeError:
+                self._inner.thinking(text)
+        else:
+            self._inner.thinking(text)
+
+    def thinking_block(self, text: str, max_chars: int = 8000) -> None:
+        preview = text[:800] if text else ""
+        if preview.strip():
+            self._sink({"event": "thinking_block", "text": preview})
+        self._inner.thinking_block(text, max_chars=max_chars)
+
+    def success(self, script_path: str, local_path: str | None = None) -> None:
+        self._sink({"event": "success", "script_path": script_path, "local_path": local_path})
+        self._inner.success(script_path, local_path)
+
+    def error(self, message: str) -> None:
+        self._sink({"event": "error", "message": message})
+        self._inner.error(message)
+
+
+def attach_json_stream_to_engineer(engineer: Any, sink: Callable[[dict[str, Any]], None]) -> None:
+    """Enable NDJSON UI events on an engineer instance."""
+    engineer._json_event_sink = sink
+    engineer.ui = StreamingUIWrapper(engineer.ui, sink)
+    sink(
+        {
+            "event": "run_started",
+            "run_id": engineer.run_id,
+            "sdk": getattr(engineer, "sdk", None),
+        }
+    )

--- a/src/reverse_api/json_stream.py
+++ b/src/reverse_api/json_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -73,9 +74,10 @@ class StreamingUIWrapper:
         if preview.strip():
             self._sink({"event": "thinking", "text": preview})
         if hasattr(self._inner, "thinking"):
-            try:
+            sig = inspect.signature(self._inner.thinking)
+            if "max_length" in sig.parameters:
                 self._inner.thinking(text, max_length=max_length)
-            except TypeError:
+            else:
                 self._inner.thinking(text)
         else:
             self._inner.thinking(text)
@@ -95,14 +97,20 @@ class StreamingUIWrapper:
         self._inner.error(message)
 
 
-def attach_json_stream_to_engineer(engineer: Any, sink: Callable[[dict[str, Any]], None]) -> None:
+def attach_json_stream_to_engineer(
+    engineer: Any,
+    sink: Callable[[dict[str, Any]], None],
+    **run_started_extra: Any,
+) -> None:
     """Enable NDJSON UI events on an engineer instance."""
     engineer._json_event_sink = sink
     engineer.ui = StreamingUIWrapper(engineer.ui, sink)
-    sink(
-        {
-            "event": "run_started",
-            "run_id": engineer.run_id,
-            "sdk": getattr(engineer, "sdk", None),
-        }
-    )
+    started: dict[str, Any] = {
+        "event": "run_started",
+        "run_id": engineer.run_id,
+        "sdk": getattr(engineer, "sdk", None),
+    }
+    for key, value in run_started_extra.items():
+        if value is not None:
+            started[key] = value
+    sink(started)

--- a/src/reverse_api/prompts/engineer/system.md
+++ b/src/reverse_api/prompts/engineer/system.md
@@ -2,7 +2,7 @@ You are tasked with analyzing a HAR (HTTP Archive) file to {mode_description} th
 
 **Core principle:** The generated output must work immediately with zero user effort. Hardcode all credentials, cookies, tokens, and session data found in the traffic. No env vars, no config files, no manual setup. If the traffic reveals a token refresh or login flow, implement automatic re-authentication so the script doesn't go stale when cookies or tokens expire.
 
-You have access to the AskUserQuestion tool to ask clarifying questions during your analysis. Use it when you need to clarify requirements, prioritize features, or choose between approaches. It supports single-select, multi-select, and free-form questions.
+You have access to the AskUserQuestion tool to ask clarifying questions during your analysis when running interactively. Use it when you need to clarify requirements, prioritize features, or choose between approaches. It supports single-select, multi-select, and free-form questions. In non-interactive or scripted CLI runs, do not use AskUserQuestion — make reasonable assumptions from the HAR and prompt instead.
 
 ## Analysis guidelines
 
@@ -11,7 +11,7 @@ These are guidelines for your analysis, not a rigid checklist — use your judgm
 1. **Read the HAR file** — understand the API surface: endpoints, methods, headers, request/response shapes, status codes
 2. **Identify auth patterns** — cookies, Bearer tokens, API keys, CSRF tokens, session tokens. Hardcode whatever you find
 3. **Extract endpoint patterns** — required vs optional params, data formats, query vs body params
-4. **Ask the user** if anything is ambiguous (which auth to prioritize, feature priorities, implementation approach)
+4. **Ask the user** if anything is ambiguous and you are in an interactive session; otherwise document assumptions in your summary
 
 {codegen_instructions}
 

--- a/src/reverse_api/tui.py
+++ b/src/reverse_api/tui.py
@@ -78,8 +78,9 @@ class ClaudeUI:
         self.console.print(" [dim]decoding starting...[/dim]")
         self.console.print()
 
-    def tool_start(self, tool_name: str, tool_input: dict | Any) -> None:
+    def tool_start(self, tool_name: str, tool_input: dict | Any, call_id: str | None = None) -> None:
         """Display when a tool starts execution."""
+        _ = call_id  # accepted for parity with json-stream; not rendered
         self._tool_count += 1
         self._tools_used.append(tool_name)
 
@@ -92,8 +93,9 @@ class ClaudeUI:
         if input_summary:
             self.console.print(f"      {input_summary}")
 
-    def tool_result(self, tool_name: str, is_error: bool = False, output: str | None = None) -> None:
+    def tool_result(self, tool_name: str, is_error: bool = False, output: str | None = None, call_id: str | None = None) -> None:
         """Display when a tool completes."""
+        _ = call_id  # accepted for parity with json-stream; not rendered
         tl = tool_name.lower()
         if is_error:
             self.console.print(f"  [dim]![/dim] [red]{self._tool_header_label(tool_name)} failed[/red]")

--- a/tests/test_cli_json_stream.py
+++ b/tests/test_cli_json_stream.py
@@ -87,54 +87,6 @@ class TestJsonStreamContract:
 
         return StreamingUIWrapper(_Inner(), events.append), events
 
-    def test_ask_user_skip_emits_balanced_tool_end(self):
-        # In non-interactive mode AskUserQuestion is auto-skipped and the SDK
-        # never streams a tool result for it; the stream must still emit a
-        # tool_end so every tool_start has a matching tool_end.
-        from claude_agent_sdk import AssistantMessage, ToolUseBlock
-
-        from reverse_api.engineer import ClaudeEngineer
-
-        events: list[dict] = []
-
-        class _Console:
-            def print(self, *a, **k):
-                pass
-
-        class _Inner:
-            console = _Console()
-
-            def tool_start(self, *a, **k):
-                pass
-
-            def tool_result(self, *a, **k):
-                pass
-
-        eng = ClaudeEngineer.__new__(ClaudeEngineer)
-        eng.interactive = False
-        eng._json_event_sink = events.append
-        eng.ui = StreamingUIWrapper(_Inner(), events.append)
-
-        async def _receive():
-            yield AssistantMessage(
-                content=[ToolUseBlock(id="t1", name="AskUserQuestion", input={"questions": []})],
-                model="claude",
-            )
-
-        class _Client:
-            def receive_response(self):
-                return _receive()
-
-        asyncio.run(eng._stream_and_handle(_Client()))
-
-        kinds = [(e["event"], e.get("name")) for e in events if e["event"].startswith("tool")]
-        assert ("tool_start", "AskUserQuestion") in kinds
-        assert ("tool_end", "AskUserQuestion") in kinds
-        assert kinds.count(("tool_start", "AskUserQuestion")) == kinds.count(
-            ("tool_end", "AskUserQuestion")
-        )
-        assert any(e["event"] == "ask_user_skipped" for e in events)
-
     def test_tool_start_input_is_structured_json_not_repr(self):
         wrapper, events = self._wrapper()
         payload = {"todos": [{"content": "x", "status": "pending"}], "flag": False}

--- a/tests/test_cli_json_stream.py
+++ b/tests/test_cli_json_stream.py
@@ -87,6 +87,54 @@ class TestJsonStreamContract:
 
         return StreamingUIWrapper(_Inner(), events.append), events
 
+    def test_ask_user_skip_emits_balanced_tool_end(self):
+        # In non-interactive mode AskUserQuestion is auto-skipped and the SDK
+        # never streams a tool result for it; the stream must still emit a
+        # tool_end so every tool_start has a matching tool_end.
+        from claude_agent_sdk import AssistantMessage, ToolUseBlock
+
+        from reverse_api.engineer import ClaudeEngineer
+
+        events: list[dict] = []
+
+        class _Console:
+            def print(self, *a, **k):
+                pass
+
+        class _Inner:
+            console = _Console()
+
+            def tool_start(self, *a, **k):
+                pass
+
+            def tool_result(self, *a, **k):
+                pass
+
+        eng = ClaudeEngineer.__new__(ClaudeEngineer)
+        eng.interactive = False
+        eng._json_event_sink = events.append
+        eng.ui = StreamingUIWrapper(_Inner(), events.append)
+
+        async def _receive():
+            yield AssistantMessage(
+                content=[ToolUseBlock(id="t1", name="AskUserQuestion", input={"questions": []})],
+                model="claude",
+            )
+
+        class _Client:
+            def receive_response(self):
+                return _receive()
+
+        asyncio.run(eng._stream_and_handle(_Client()))
+
+        kinds = [(e["event"], e.get("name")) for e in events if e["event"].startswith("tool")]
+        assert ("tool_start", "AskUserQuestion") in kinds
+        assert ("tool_end", "AskUserQuestion") in kinds
+        assert kinds.count(("tool_start", "AskUserQuestion")) == kinds.count(
+            ("tool_end", "AskUserQuestion")
+        )
+        assert any(e["event"] == "ask_user_skipped" for e in events)
+
     def test_tool_start_input_is_structured_json_not_repr(self):
         wrapper, events = self._wrapper()
         payload = {"todos": [{"content": "x", "status": "pending"}], "flag": False}

--- a/tests/test_cli_json_stream.py
+++ b/tests/test_cli_json_stream.py
@@ -1,0 +1,71 @@
+"""Tests for --json-stream NDJSON CLI output."""
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from reverse_api.cli import agent, engineer, main
+
+
+class TestJsonStreamAgent:
+    def test_agent_json_stream_emits_ndjson_and_result(self):
+        runner = CliRunner()
+        fake_result = {
+            "run_id": "abc123",
+            "mode": "auto",
+            "script_path": "/tmp/api_client.py",
+            "usage": {},
+        }
+
+        def fake_capture(**kwargs):
+            sink = kwargs.get("json_event_sink")
+            if sink:
+                sink({"event": "run_started", "run_id": "abc123", "sdk": "claude"})
+            return fake_result
+
+        with patch("reverse_api.cli.run_agent_capture", side_effect=fake_capture):
+            result = runner.invoke(
+                agent,
+                ["--json-stream", "-p", "capture api", "-u", "https://example.com"],
+            )
+
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.strip().split("\n") if ln]
+        assert len(lines) >= 2
+        events = [json.loads(ln) for ln in lines]
+        assert events[0]["event"] == "run_started"
+        assert events[-1]["event"] == "result"
+        assert events[-1]["status"] == "ok"
+        assert events[-1]["run_id"] == "abc123"
+
+    def test_agent_json_stream_implies_no_interactive(self):
+        runner = CliRunner()
+        with patch("reverse_api.cli.run_agent_capture") as mock_run:
+            mock_run.return_value = {"run_id": "x", "mode": "auto", "usage": {}}
+            runner.invoke(agent, ["--json-stream", "-p", "x"])
+        assert mock_run.call_args.kwargs["interactive"] is False
+
+
+class TestJsonStreamEngineer:
+    def test_engineer_json_stream_emits_result_event(self):
+        runner = CliRunner()
+        def fake_engineer(run_id, **kwargs):
+            sink = kwargs.get("json_event_sink")
+            if sink:
+                sink({"event": "run_started", "run_id": run_id, "sdk": "claude"})
+            return {"script_path": "/tmp/c.py", "usage": {}}
+
+        with patch("reverse_api.cli.run_engineer", side_effect=fake_engineer):
+            result = runner.invoke(engineer, ["abc123", "--json-stream", "-p", "add tests"])
+
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.strip().split("\n") if ln]
+        events = [json.loads(ln) for ln in lines]
+        assert events[-1]["event"] == "result"
+        assert events[-1]["run_id"] == "abc123"
+
+    def test_help_lists_json_stream(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["agent", "--help"])
+        assert "--json-stream" in result.output

--- a/tests/test_cli_json_stream.py
+++ b/tests/test_cli_json_stream.py
@@ -69,3 +69,13 @@ class TestJsonStreamEngineer:
         runner = CliRunner()
         result = runner.invoke(main, ["agent", "--help"])
         assert "--json-stream" in result.output
+
+    def test_engineer_json_stream_missing_run_id_emits_result_event(self):
+        runner = CliRunner()
+        result = runner.invoke(engineer, ["--json-stream"])
+        assert result.exit_code == 2
+        payload = json.loads(result.output.strip())
+        assert payload["event"] == "result"
+        assert payload["status"] == "error"
+        assert payload["error_kind"] == "misuse"
+        assert "RUN_ID" in payload["error"]

--- a/tests/test_cli_json_stream.py
+++ b/tests/test_cli_json_stream.py
@@ -1,11 +1,13 @@
 """Tests for --json-stream NDJSON CLI output."""
 
+import asyncio
 import json
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from reverse_api.cli import agent, engineer, main
+from reverse_api.json_stream import StreamingUIWrapper
 
 
 class TestJsonStreamAgent:
@@ -70,6 +72,102 @@ class TestJsonStreamEngineer:
         result = runner.invoke(main, ["agent", "--help"])
         assert "--json-stream" in result.output
 
+class TestJsonStreamContract:
+    """The event payloads must stay machine-parseable."""
+
+    def _wrapper(self):
+        events: list[dict] = []
+
+        class _Inner:
+            def tool_start(self, *a, **k):
+                pass
+
+            def tool_result(self, *a, **k):
+                pass
+
+        return StreamingUIWrapper(_Inner(), events.append), events
+
+    def test_tool_start_input_is_structured_json_not_repr(self):
+        wrapper, events = self._wrapper()
+        payload = {"todos": [{"content": "x", "status": "pending"}], "flag": False}
+        wrapper.tool_start("updateTodos", payload, call_id="C1")
+
+        # The event survives a JSON round-trip with input as a nested object,
+        # not a str(dict) repr (which would carry single quotes / Python False).
+        roundtripped = json.loads(json.dumps(events[0]))
+        assert roundtripped["input"] == payload
+        assert isinstance(roundtripped["input"], dict)
+        assert roundtripped["call_id"] == "C1"
+
+    def test_tool_start_and_end_share_call_id(self):
+        wrapper, events = self._wrapper()
+        wrapper.tool_start("shell", {"command": "ls"}, call_id="abc")
+        wrapper.tool_result("shell", False, "ok", call_id="abc")
+        assert events[0]["event"] == "tool_start" and events[0]["call_id"] == "abc"
+        assert events[1]["event"] == "tool_end" and events[1]["call_id"] == "abc"
+
+    def test_cursor_collapses_running_deltas_to_one_tool_start(self):
+        from reverse_api.cursor_engineer import CursorEngineer
+
+        eng = CursorEngineer.__new__(CursorEngineer)
+        eng._cursor_started_calls = set()
+        eng.interactive = False
+        eng._json_event_sink = None
+        eng._cursor_thinking_acc = ""
+        eng._cursor_assistant_acc = ""
+        captured: list[tuple] = []
+
+        class _UI:
+            verbose = False
+
+            class console:
+                @staticmethod
+                def print(*a, **k):
+                    pass
+
+            def todo_updated(self, todos):
+                pass
+
+            def tool_start(self, name, args, call_id=None):
+                captured.append(("start", call_id))
+
+            def tool_result(self, name, is_err, out, call_id=None):
+                captured.append(("end", call_id))
+
+        class _Store:
+            def save_tool_start(self, *a):
+                pass
+
+            def save_tool_result(self, *a):
+                pass
+
+            def save_todos(self, *a):
+                pass
+
+        eng.ui = _UI()
+        eng.message_store = _Store()
+
+        async def run():
+            for n in (1, 2, 3):  # growing args, same call
+                await eng._dispatch_stream_event(
+                    {
+                        "type": "tool_call",
+                        "name": "updateTodos",
+                        "status": "running",
+                        "callId": "T1",
+                        "args": {"todos": [{"content": str(i)} for i in range(n)]},
+                    }
+                )
+            await eng._dispatch_stream_event(
+                {"type": "tool_call", "name": "updateTodos", "status": "completed", "callId": "T1", "result": "ok"}
+            )
+
+        asyncio.run(run())
+        assert [c[0] for c in captured] == ["start", "end"]
+        assert eng._cursor_started_calls == set()  # cleaned up on terminal event
+
+
+class TestJsonStreamEngineerMisuse:
     def test_engineer_json_stream_missing_run_id_emits_result_event(self):
         runner = CliRunner()
         result = runner.invoke(engineer, ["--json-stream"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,6 @@ class TestDefaultConfig:
         assert DEFAULT_CONFIG["output_dir"] is None
         assert DEFAULT_CONFIG["output_language"] == "python"
         assert DEFAULT_CONFIG["real_time_sync"] is True
-        assert DEFAULT_CONFIG["cursor_model"] == "composer-2"
+        assert DEFAULT_CONFIG["cursor_model"] == "composer-2.5"
         assert DEFAULT_CONFIG["cursor_web_search"] is True
         assert DEFAULT_CONFIG["cursor_setting_sources"] is None

--- a/tests/test_cursor_engineer.py
+++ b/tests/test_cursor_engineer.py
@@ -127,3 +127,20 @@ def test_cursor_stream_buffers_merge_assistant(tmp_path: Path) -> None:
     eng._cursor_feed_thinking(" t1")
     eng._cursor_feed_thinking(" t2")
     assert eng._cursor_thinking_acc == " t1 t2"
+
+
+def test_cursor_reset_clears_started_calls(har_path: Path) -> None:
+    """_cursor_started_calls is cleared each turn so stale ids can't suppress tool_start."""
+    with patch.dict("os.environ", {"CURSOR_API_KEY": "x"}):
+        with patch("reverse_api.cursor_engineer._ensure_cursor_bridge_deps", return_value=None):
+            eng = CursorEngineer(
+                run_id="r4",
+                har_path=har_path,
+                prompt="p",
+                sdk="cursor",
+                interactive=False,
+                verbose=False,
+            )
+    eng._cursor_started_calls.add("stale-call-id")
+    eng._cursor_reset_stream_buffers()
+    assert eng._cursor_started_calls == set()

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -402,6 +402,51 @@ class TestHandleToolPermission:
             )
             assert result.updated_input["answers"]["What?"] == "user answer"
 
+    @pytest.mark.asyncio
+    async def test_ask_user_question_non_interactive_stub(self, tmp_path):
+        """AskUserQuestion returns a fixed message when interactive=False."""
+        from reverse_api.base_engineer import NON_INTERACTIVE_ASK_USER_MESSAGE
+
+        eng = self._make_engineer(tmp_path)
+        eng.interactive = False
+
+        with patch("reverse_api.base_engineer.questionary.text") as mock_text:
+            result = await eng._handle_tool_permission(
+                "AskUserQuestion",
+                {"questions": [{"question": "What?", "header": "", "multiSelect": False, "options": []}]},
+                None,
+            )
+            mock_text.assert_not_called()
+            assert result.updated_input["answers"]["What?"] == NON_INTERACTIVE_ASK_USER_MESSAGE
+
+
+class TestAskUserQuestions:
+    """Test _ask_user_questions routing."""
+
+    def _make_engineer(self, tmp_path, *, interactive: bool = True):
+        har_path = tmp_path / "test.har"
+        har_path.touch()
+        with patch("reverse_api.base_engineer.get_scripts_dir", return_value=tmp_path / "scripts"):
+            with patch("reverse_api.base_engineer.MessageStore"):
+                eng = ClaudeEngineer(
+                    run_id="test123",
+                    har_path=har_path,
+                    prompt="test prompt",
+                    output_dir=str(tmp_path),
+                    interactive=interactive,
+                )
+                return eng
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_no_questionary(self, tmp_path):
+        from reverse_api.base_engineer import NON_INTERACTIVE_ASK_USER_MESSAGE
+
+        eng = self._make_engineer(tmp_path, interactive=False)
+        answers = await eng._ask_user_questions(
+            [{"question": "Pick auth?", "header": "", "multiSelect": False, "options": []}]
+        )
+        assert answers["Pick auth?"] == NON_INTERACTIVE_ASK_USER_MESSAGE
+
 
 class TestClaudeEngineerAnalyzeAndGenerate:
     """Test analyze_and_generate method."""

--- a/website/content/docs/cli/scripted-usage.mdx
+++ b/website/content/docs/cli/scripted-usage.mdx
@@ -40,7 +40,7 @@ reverse-api-engineer agent \
   --json-stream
 ```
 
-Common event types: `run_started`, `tool_start`, `tool_end`, `thinking`, `ask_user_skipped`, `result`.
+Common event types: `run_started` (includes `run_id`, `sdk`; agent runs also include `mode`, `url`, `command`), `tool_start`, `tool_end`, `thinking`, `ask_user_skipped`, `result`.
 
 ### List and inspect runs
 

--- a/website/content/docs/cli/scripted-usage.mdx
+++ b/website/content/docs/cli/scripted-usage.mdx
@@ -14,6 +14,12 @@ When `--json` is set:
 - **stderr** receives Rich logs and progress updates.
 - The process exits with a **stable exit code**.
 
+When `--json-stream` is set (on `agent` and `engineer`):
+
+- **stdout** receives **NDJSON**: one JSON object per line while the run progresses, then a final `{"event":"result",...}` line with the same fields as `--json`.
+- **stderr** receives Rich logs (same as `--json`).
+- Implies **non-interactive** mode; `AskUserQuestion` is auto-answered with a fixed message instead of prompting on stdin.
+
 ## Examples
 
 ### Run an autonomous capture and read the result as JSON
@@ -24,6 +30,17 @@ reverse-api-engineer agent \
   --url https://example.com/jobs \
   --json | jq
 ```
+
+### Stream progress as NDJSON (wrapper agents)
+
+```bash
+reverse-api-engineer agent \
+  --prompt "capture the public jobs api" \
+  --url https://example.com/jobs \
+  --json-stream
+```
+
+Common event types: `run_started`, `tool_start`, `tool_end`, `thinking`, `ask_user_skipped`, `result`.
 
 ### List and inspect runs
 

--- a/website/content/docs/configuration/models.mdx
+++ b/website/content/docs/configuration/models.mdx
@@ -42,7 +42,7 @@ The full default config:
   "agent_provider": "auto",
   "claude_code_model": "claude-sonnet-4-6",
   "collector_model": "claude-sonnet-4-6",
-  "cursor_model": "composer-2",
+  "cursor_model": "composer-2.5",
   "cursor_web_search": true,
   "cursor_setting_sources": null,
   "copilot_model": "gpt-5",
@@ -64,5 +64,5 @@ for the available model IDs. Set them via the `opencode_model` and
 ## Copilot and Cursor users
 
 Copilot uses `copilot_model` (default `gpt-5`). Cursor uses `cursor_model`
-(default `composer-2`) plus `cursor_web_search` / `cursor_setting_sources`
+(default `composer-2.5`) plus `cursor_web_search` / `cursor_setting_sources`
 for controlling which Cursor settings layers are loaded.

--- a/website/content/docs/configuration/sdks.mdx
+++ b/website/content/docs/configuration/sdks.mdx
@@ -55,7 +55,7 @@ so WebFetch/WebSearch and configured tools match your desktop setup.
 ```json
 {
   "sdk": "cursor",
-  "cursor_model": "composer-2",
+  "cursor_model": "composer-2.5",
   "cursor_web_search": true,
   "cursor_setting_sources": null
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **AskUserQuestion in scripted mode**: When `--json`, `--no-interactive`, or `--json-stream` is used, `AskUserQuestion` no longer opens questionary prompts. Each question receives a fixed auto-reply telling the model to assume reasonable answers or stop and ask the caller to rerun with a clearer prompt.
- **`--json-stream`**: New flag on `agent` and `engineer` emits NDJSON progress events on stdout and ends with `{"event":"result",...}` using the same schema as `--json`. Logs stay on stderr.
- **Cursor default model**: Bumped default `cursor_model` from `composer-2` to `composer-2.5`.

## PR review follow-ups

- `engineer --json-stream` without `RUN_ID` now emits a machine-readable `result` event (same as `--json`).
- Removed undocumented `agent_started` event; agent runs include `mode`, `url`, and `command` on `run_started` instead.
- `StreamingUIWrapper.thinking` uses `inspect.signature` instead of a broad `TypeError` handler.

## SDK coverage

| SDK | AskUserQuestion |
|-----|-----------------|
| Claude / agent auto | `can_use_tool` → `_ask_user_questions` |
| Copilot | custom `ask_user_question` tool |
| Cursor | `ask_user_skipped` when an ask-user-like tool starts |
| OpenCode | N/A |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49a71a38-f503-4946-abf6-d60f4a7e8e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49a71a38-f503-4946-abf6-d60f4a7e8e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AskUserQuestion non-interactive in scripted runs and add --json-stream for NDJSON progress with structured tool input and call_id correlation. Event streams now guarantee balanced tool_start/tool_end, dedup Cursor running deltas (reset each turn), and the default Cursor model is composer-2.5.

- **New Features**
  - AskUserQuestion now auto-replies in scripted runs with a fixed message. Emits ask_user_skipped with a count. Applied to Claude/auto and Copilot; Cursor emits the skip event when an ask-user-like tool starts. The stream emits a matching tool_end so every tool_start is balanced.
  - Added --json-stream to agent and engineer. Streams NDJSON events (run_started, tool_start, tool_end, thinking, ask_user_skipped) and ends with {"event":"result",...} (logs on stderr, implies non-interactive). Agent runs fold mode, url, and command into run_started and removed agent_started. tool_start includes structured input and call_id; tool_end includes call_id. Cursor collapses multiple running deltas to one tool_start per call_id and clears the dedup set between turns. engineer --json-stream without RUN_ID now outputs a machine-readable result event.
  - Default cursor_model is now composer-2.5.

- **Migration**
  - Scripted runs will not prompt for AskUserQuestion when using --json, --no-interactive, or --json-stream. Remove these flags to enable prompts.
  - Consumers using --json-stream should parse NDJSON, correlate tool_start/tool_end by call_id, and read the final result event for the outcome.
  - Override cursor_model to composer-2 if you need the previous default.

<sup>Written for commit d15234b8708aa8b88ea2f7dab8178fb160a80331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `--json-stream` (NDJSON progress streaming) to the `agent` and `engineer` commands, makes `AskUserQuestion` return a fixed stub reply in non-interactive/scripted runs across all SDK paths, and bumps the default Cursor model to `composer-2.5`.

- **`--json-stream`**: A new `StreamingUIWrapper` intercepts `tool_start`, `tool_result`, `thinking`, etc. and writes one JSON object per line to stdout, ending with `{\"event\":\"result\",...}`. The `agent_started` asymmetry from a previous review has been removed; `run_started` is now the single startup event.
- **Non-interactive `AskUserQuestion`**: `_ask_user_questions` in `BaseEngineer` routes to a stub that returns `NON_INTERACTIVE_ASK_USER_MESSAGE` for every question when `self.interactive` is `False`; Claude/auto, Copilot, and Cursor paths all route through it. The system prompt is updated to tell the LLM to avoid `AskUserQuestion` in scripted runs.
- **Cursor delta dedup**: `_cursor_started_calls` tracks announced `call_id`s so only the first `running` delta per logical tool call fires `tool_start`; the set is cleared at each turn boundary to prevent stale IDs from suppressing future events.

<h3>Confidence Score: 5/5</h3>

The changes are additive and well-tested; no existing interactive or non-streaming path is altered.

All three feature areas (NDJSON streaming, non-interactive AskUserQuestion stub, Cursor dedup) have corresponding tests, and the only defect found is a hardcoded 500-char cap in the stream event preview that should use the `max_length` parameter — a minor inconsistency with no correctness impact on existing users.

No files require special attention beyond the `max_length` nit in `json_stream.py`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/json_stream.py | New file: StreamingUIWrapper delegates UI events to a JSON sink; the `thinking` preview cap is hardcoded to 500 instead of using the `max_length` param, and the unreachable `else` branch on line 91 (already flagged in a previous thread) still raises AttributeError if reached. |
| src/reverse_api/base_engineer.py | Adds `_ask_user_questions` routing stub, `_emit_json_event` helper, and `_is_ask_user_tool_name` static; logic is correct and well-tested. |
| src/reverse_api/cli.py | Adds `--json-stream` flag to `agent` and `engineer`, wires up the sink, and moves the final result write inside the `with _quiet_consoles_for_json()` block; changes are mechanically correct. |
| src/reverse_api/cursor_engineer.py | Adds per-call_id dedup set `_cursor_started_calls` and clears it at turn boundaries; the reset-on-new-turn strategy is sound and well-covered by tests. |
| tests/test_cli_json_stream.py | New test file covering agent/engineer json-stream CLI wiring, misuse payloads, event contract round-trips, and Cursor delta dedup; coverage looks solid. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/reverse_api/json_stream.py:80-81
The NDJSON `thinking` event preview is capped at a hardcoded 500 characters rather than the method's own `max_length` parameter. When a caller passes `max_length=100`, the inner TUI truncates at 100 chars but the stream event still emits up to 500 chars, so machine consumers see a different slice of text than the TUI renders.

```suggestion
    def thinking(self, text: str, max_length: int = 500) -> None:
        preview = text[:max_length] if text else ""
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["cursor: reset \_cursor\_started\_calls betw..."](https://github.com/kalil0321/reverse-api-engineer/commit/d15234b8708aa8b88ea2f7dab8178fb160a80331) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33772265)</sub>

<!-- /greptile_comment -->