### PR TITLE
Add C# as a supported output language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Go output language**: `output_language: "go"` is now supported alongside python/javascript/typescript, generating a standard-library-first (`net/http`, `encoding/json`) Go program, with the same auth-hardcoding/refresh and bot-detection-fallback guidance as the other languages.
 - **Java output language**: `output_language: "java"` is now supported alongside python/javascript/typescript, generating a small Maven project using `java.net.http.HttpClient` (JDK 11+, no HTTP library dependency) and Gson for JSON, with the same auth-hardcoding/refresh guidance as the other languages.
+- **C# output language**: `output_language: "csharp"` is now supported alongside python/javascript/typescript, generating a minimal .NET project using `System.Net.Http.HttpClient` and `System.Text.Json` (both part of the .NET 5+ base class library — no NuGet dependency needed), with the same auth-hardcoding/refresh guidance as the other languages.
 
 ## [0.10.0] - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Settings live in `~/.reverse-api/config.json` and can be edited via `/settings` 
 
 - **Models**: Sonnet 4.6 (default), Opus 4.6 (most capable), Haiku 4.5 (fastest). For OpenCode see [models.dev](https://models.dev).
 - **SDK**: `claude` (default), `opencode`, `cursor`, or `copilot` (GitHub Copilot).
-- **Output language**: `python`, `javascript`, `typescript`, `go`, or `java`.
+- **Output language**: `python`, `javascript`, `typescript`, `go`, `java`, or `csharp`.
 
 ## CLI
 

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -502,7 +502,11 @@ class BaseEngineer(ABC):
             # double-quoting — output_dir (and so scripts_dir) isn't
             # guaranteed free of shell metacharacters, and naive f'"{path}"'
             # still lets $()/backticks expand inside double quotes.
-            csproj = shlex.quote(f"{self.scripts_dir}/ApiClient.csproj")
+            # .resolve(): a relative --output-dir would otherwise be
+            # re-interpreted against the agent's cwd (scripts_dir.parent.
+            # parent) instead of the original cwd it was relative to,
+            # pointing --project at the wrong, doubly-nested location.
+            csproj = shlex.quote(str(self.scripts_dir.resolve() / "ApiClient.csproj"))
             return f"dotnet run --project {csproj}"
         return {
             "python": "python api_client.py",

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -36,6 +36,7 @@ class BaseEngineer(ABC):
         "typescript": ".ts",
         "go": ".go",
         "java": ".java",
+        "csharp": ".cs",
     }
 
     def __init__(
@@ -444,6 +445,7 @@ class BaseEngineer(ABC):
             "typescript": "TypeScript",
             "go": "Go",
             "java": "Java",
+            "csharp": "C#",
         }.get(self.output_language, "Python")
 
     def _get_existing_client_guidance(self) -> str:
@@ -494,6 +496,7 @@ class BaseEngineer(ABC):
             "javascript": "node api_client.js",
             "typescript": "npx tsx api_client.ts",
             "go": "go run api_client.go",
+            "csharp": "dotnet run",
         }.get(self.output_language, "python api_client.py")
 
     def _get_codegen_instructions(self) -> str:
@@ -610,6 +613,8 @@ class BaseEngineer(ABC):
             )
         elif self.output_language == "java":
             return base + f"\n3. `{self.scripts_dir}/pom.xml` - Maven project file (Gson dependency, exec-maven-plugin)"
+        elif self.output_language == "csharp":
+            return base + f"\n3. `{self.scripts_dir}/ApiClient.csproj` - .NET project file"
         return base
 
     @abstractmethod

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -491,12 +491,20 @@ class BaseEngineer(ABC):
             # requires ("symbolic reference class is not accessible").
             pom = shlex.quote(str(self.scripts_dir.resolve() / "pom.xml"))
             return f"mvn -q -f {pom} compile exec:exec"
+        if self.output_language == "csharp":
+            # Unlike python/node/npx (which happily take a plain relative
+            # filename regardless of the agent's actual cwd, scripts_dir.
+            # parent.parent — see analyze_and_generate's ClaudeAgentOptions),
+            # a bare `dotnet run` only looks for a project file in the
+            # current directory. --project points it straight at this run's
+            # own .csproj regardless of cwd, rather than relying on the
+            # agent to cd there itself first.
+            return f'dotnet run --project "{self.scripts_dir}/ApiClient.csproj"'
         return {
             "python": "python api_client.py",
             "javascript": "node api_client.js",
             "typescript": "npx tsx api_client.ts",
             "go": "go run api_client.go",
-            "csharp": "dotnet run",
         }.get(self.output_language, "python api_client.py")
 
     def _get_codegen_instructions(self) -> str:

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -498,8 +498,12 @@ class BaseEngineer(ABC):
             # a bare `dotnet run` only looks for a project file in the
             # current directory. --project points it straight at this run's
             # own .csproj regardless of cwd, rather than relying on the
-            # agent to cd there itself first.
-            return f'dotnet run --project "{self.scripts_dir}/ApiClient.csproj"'
+            # agent to cd there itself first. shlex.quote(), not manual
+            # double-quoting — output_dir (and so scripts_dir) isn't
+            # guaranteed free of shell metacharacters, and naive f'"{path}"'
+            # still lets $()/backticks expand inside double quotes.
+            csproj = shlex.quote(f"{self.scripts_dir}/ApiClient.csproj")
+            return f"dotnet run --project {csproj}"
         return {
             "python": "python api_client.py",
             "javascript": "node api_client.js",

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -1085,6 +1085,7 @@ def handle_settings(mode_color=THEME_PRIMARY):
             Choice(title="typescript", value="typescript"),
             Choice(title="go", value="go"),
             Choice(title="java", value="java"),
+            Choice(title="csharp", value="csharp"),
             Choice(title="back", value="back"),
         ]
         lang = questionary.select(

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -20,7 +20,7 @@ DEFAULT_CONFIG = {
     "opencode_model": "claude-opus-4-6",
     "opencode_provider": "anthropic",
     "output_dir": None,  # None means use ~/.reverse-api/runs
-    "output_language": "python",  # "python", "javascript", "typescript", "go", or "java"
+    "output_language": "python",  # "python", "javascript", "typescript", "go", "java", or "csharp"
     "real_time_sync": True,  # Enable real-time file sync during engineering
     "sdk": "claude",  # "claude", "opencode", "copilot", or "cursor"
 }

--- a/src/reverse_api/engineer.py
+++ b/src/reverse_api/engineer.py
@@ -232,7 +232,7 @@ def run_reverse_engineering(
         cursor_setting_sources: Optional explicit list (overrides cursor_web_search), e.g. ["project","user","all"].
         enable_sync: Enable real-time file syncing during engineering
         is_fresh: Whether to start fresh (ignore previous scripts)
-        output_language: Target language - "python", "javascript", "typescript", "go", or "java"
+        output_language: Target language - "python", "javascript", "typescript", "go", "java", or "csharp"
         output_mode: Output mode - "client" for API client code, "docs" for OpenAPI specification
     """
     if sdk == "opencode":

--- a/src/reverse_api/prompts/__init__.py
+++ b/src/reverse_api/prompts/__init__.py
@@ -54,7 +54,7 @@ def load_language_partial(language: str, **kwargs: str) -> str:
     """Load the language-specific codegen instructions partial.
 
     Args:
-        language: One of "python", "javascript", "typescript", "go", "java".
+        language: One of "python", "javascript", "typescript", "go", "java", "csharp".
         **kwargs: Placeholder values (scripts_dir, client_filename, run_command).
     """
     return load(f"partials/_language_{language}", **kwargs)

--- a/src/reverse_api/prompts/partials/_language_csharp.md
+++ b/src/reverse_api/prompts/partials/_language_csharp.md
@@ -1,7 +1,7 @@
 **Generate a C# program** that replicates the API calls found in the traffic. The following are guidelines — use your judgment on what's appropriate for the specific API:
 
 - Use `System.Net.Http.HttpClient` and `System.Text.Json` — both are part of the .NET base class library (available since .NET Core 3.0), so no external NuGet package is needed for HTTP or JSON
-- Create a minimal project file (`.csproj`) so the program can be run with a single command. Target `net8.0` by default, but this only works if that SDK is actually installed — if `dotnet run` reports the target framework isn't supported, lower `<TargetFramework>` to whatever the installed SDK does support (e.g. `net6.0`) and retry; both libraries above work fine on any of these versions, only the project file's stated target needs to match what's actually installed
+- Create a minimal project file (`.csproj`) so the program can be run with a single command. Target `net8.0` by default, but this only works if that SDK/runtime is actually installed — if `dotnet run` reports the target framework isn't supported or the required runtime isn't installed, change `<TargetFramework>` to match what's actually there (check `dotnet --version`; a machine with only a newer SDK needs a higher target like `net10.0`, an older one a lower target like `net6.0`) and retry; both libraries above work fine on any of these versions, only the project file's stated target needs to match the installed SDK
 - Create a separate method for each distinct API endpoint, with a small record or class for its response shape
 - Reuse one `HttpClient` instance across requests rather than creating a new one per call
 - Include a `Main` method with example usage

--- a/src/reverse_api/prompts/partials/_language_csharp.md
+++ b/src/reverse_api/prompts/partials/_language_csharp.md
@@ -1,0 +1,22 @@
+**Generate a C# program** that replicates the API calls found in the traffic. The following are guidelines — use your judgment on what's appropriate for the specific API:
+
+- Use `System.Net.Http.HttpClient` and `System.Text.Json` — both are part of the .NET base class library (.NET 5+), so no external NuGet package is needed for HTTP or JSON
+- Create a minimal project file (`.csproj`, targeting `net8.0`) so the program can be run with a single command
+- Create a separate method for each distinct API endpoint, with a small record or class for its response shape
+- Reuse one `HttpClient` instance across requests rather than creating a new one per call
+- Include a `Main` method with example usage
+
+**Authentication & credentials:**
+- Hardcode all cookies, tokens, session IDs, and auth headers found in the traffic directly in the program
+- The user should be able to run the program immediately with zero configuration — no env vars, no config files, no manual setup beyond what's generated
+- If the API uses cookies, construct the `HttpClient` with an `HttpClientHandler` that has a `CookieContainer` set, so cookies persist across requests
+- If the API uses Bearer tokens or API keys, hardcode them in the request headers (e.g. via `DefaultRequestHeaders`)
+- Handle auth refresh so the program doesn't go stale: if you see a token refresh endpoint, OAuth refresh flow, or login endpoint in the traffic, implement automatic re-authentication when a request returns 401/403. If cookies have expiry, re-fetch them before they expire
+
+**Testing:**
+- Run: `{run_command}`
+- You have up to 5 attempts to fix issues
+
+Save the program to: `{scripts_dir}/{client_filename}`
+Save documentation to: `{scripts_dir}/README.md`
+Save the project file to: `{scripts_dir}/ApiClient.csproj`

--- a/src/reverse_api/prompts/partials/_language_csharp.md
+++ b/src/reverse_api/prompts/partials/_language_csharp.md
@@ -1,7 +1,7 @@
 **Generate a C# program** that replicates the API calls found in the traffic. The following are guidelines — use your judgment on what's appropriate for the specific API:
 
-- Use `System.Net.Http.HttpClient` and `System.Text.Json` — both are part of the .NET base class library (.NET 5+), so no external NuGet package is needed for HTTP or JSON
-- Create a minimal project file (`.csproj`, targeting `net8.0`) so the program can be run with a single command
+- Use `System.Net.Http.HttpClient` and `System.Text.Json` — both are part of the .NET base class library (available since .NET Core 3.0), so no external NuGet package is needed for HTTP or JSON
+- Create a minimal project file (`.csproj`) so the program can be run with a single command. Target `net8.0` by default, but this only works if that SDK is actually installed — if `dotnet run` reports the target framework isn't supported, lower `<TargetFramework>` to whatever the installed SDK does support (e.g. `net6.0`) and retry; both libraries above work fine on any of these versions, only the project file's stated target needs to match what's actually installed
 - Create a separate method for each distinct API endpoint, with a small record or class for its response shape
 - Reuse one `HttpClient` instance across requests rather than creating a new one per call
 - Include a `Main` method with example usage

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -274,12 +274,23 @@ class TestBaseEngineerHelpers:
         assert Path(pom_arg).is_absolute()
         assert pom_arg == str(eng.scripts_dir.resolve() / "pom.xml")
     def test_get_run_command_csharp(self, tmp_path):
-        """Run command for C# points --project at this run's own .csproj,
-        not a bare `dotnet run` — the agent's cwd is scripts_dir.parent.
-        parent (see analyze_and_generate), and dotnet only looks for a
-        project file in the current directory."""
+        """Run command for C# points --project at this run's own (shell-
+        quoted) .csproj, not a bare `dotnet run` — the agent's cwd is
+        scripts_dir.parent.parent (see analyze_and_generate), and dotnet
+        only looks for a project file in the current directory."""
         eng = self._make_engineer(tmp_path, output_language="csharp")
-        assert eng._get_run_command() == f'dotnet run --project "{eng.scripts_dir}/ApiClient.csproj"'
+        expected_csproj = shlex.quote(f"{eng.scripts_dir}/ApiClient.csproj")
+        assert eng._get_run_command() == f"dotnet run --project {expected_csproj}"
+
+    def test_get_run_command_csharp_quotes_metacharacters(self, tmp_path):
+        """A scripts_dir containing shell metacharacters must round-trip
+        back to the literal path, not be left open to $()/backtick
+        expansion — what the naive f'"{path}"' approach got wrong."""
+        eng = self._make_engineer(tmp_path, output_language="csharp")
+        eng.scripts_dir = Path("/tmp/weird$(rm -rf ~) dir")
+        tokens = shlex.split(eng._get_run_command())
+        assert tokens[:2] == ["dotnet", "run"]
+        assert tokens[3] == f"{eng.scripts_dir}/ApiClient.csproj"
 
     def test_get_run_command_unknown(self, tmp_path):
         """Unknown language defaults to Python command."""

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -202,6 +202,10 @@ class TestBaseEngineerHelpers:
         """Java extension."""
         eng = self._make_engineer(tmp_path, output_language="java")
         assert eng._get_output_extension() == ".java"
+    def test_get_output_extension_csharp(self, tmp_path):
+        """C# extension."""
+        eng = self._make_engineer(tmp_path, output_language="csharp")
+        assert eng._get_output_extension() == ".cs"
 
     def test_get_output_extension_unknown(self, tmp_path):
         """Unknown language defaults to .py."""
@@ -269,6 +273,10 @@ class TestBaseEngineerHelpers:
         pom_arg = tokens[3]
         assert Path(pom_arg).is_absolute()
         assert pom_arg == str(eng.scripts_dir.resolve() / "pom.xml")
+    def test_get_run_command_csharp(self, tmp_path):
+        """Run command for C#."""
+        eng = self._make_engineer(tmp_path, output_language="csharp")
+        assert eng._get_run_command() == "dotnet run"
 
     def test_get_run_command_unknown(self, tmp_path):
         """Unknown language defaults to Python command."""
@@ -327,6 +335,11 @@ class TestBaseEngineerBuildPrompt:
         eng = self._make_engineer(tmp_path, output_language="java")
         system_prompt, user_message = eng._build_prompts()
         assert "Java program" in system_prompt
+    def test_csharp_prompt(self, tmp_path):
+        """C# prompt includes C#-specific instructions."""
+        eng = self._make_engineer(tmp_path, output_language="csharp")
+        system_prompt, user_message = eng._build_prompts()
+        assert "C# program" in system_prompt
         assert "HttpClient" in system_prompt
 
     def test_docs_prompt(self, tmp_path):

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -274,9 +274,12 @@ class TestBaseEngineerHelpers:
         assert Path(pom_arg).is_absolute()
         assert pom_arg == str(eng.scripts_dir.resolve() / "pom.xml")
     def test_get_run_command_csharp(self, tmp_path):
-        """Run command for C#."""
+        """Run command for C# points --project at this run's own .csproj,
+        not a bare `dotnet run` — the agent's cwd is scripts_dir.parent.
+        parent (see analyze_and_generate), and dotnet only looks for a
+        project file in the current directory."""
         eng = self._make_engineer(tmp_path, output_language="csharp")
-        assert eng._get_run_command() == "dotnet run"
+        assert eng._get_run_command() == f'dotnet run --project "{eng.scripts_dir}/ApiClient.csproj"'
 
     def test_get_run_command_unknown(self, tmp_path):
         """Unknown language defaults to Python command."""

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -274,12 +274,12 @@ class TestBaseEngineerHelpers:
         assert Path(pom_arg).is_absolute()
         assert pom_arg == str(eng.scripts_dir.resolve() / "pom.xml")
     def test_get_run_command_csharp(self, tmp_path):
-        """Run command for C# points --project at this run's own (shell-
-        quoted) .csproj, not a bare `dotnet run` — the agent's cwd is
+        """Run command for C# points --project at this run's own (resolved,
+        shell-quoted) .csproj, not a bare `dotnet run` — the agent's cwd is
         scripts_dir.parent.parent (see analyze_and_generate), and dotnet
         only looks for a project file in the current directory."""
         eng = self._make_engineer(tmp_path, output_language="csharp")
-        expected_csproj = shlex.quote(f"{eng.scripts_dir}/ApiClient.csproj")
+        expected_csproj = shlex.quote(str(eng.scripts_dir.resolve() / "ApiClient.csproj"))
         assert eng._get_run_command() == f"dotnet run --project {expected_csproj}"
 
     def test_get_run_command_csharp_quotes_metacharacters(self, tmp_path):
@@ -290,7 +290,20 @@ class TestBaseEngineerHelpers:
         eng.scripts_dir = Path("/tmp/weird$(rm -rf ~) dir")
         tokens = shlex.split(eng._get_run_command())
         assert tokens[:2] == ["dotnet", "run"]
-        assert tokens[3] == f"{eng.scripts_dir}/ApiClient.csproj"
+        assert tokens[3] == str(eng.scripts_dir.resolve() / "ApiClient.csproj")
+
+    def test_get_run_command_csharp_resolves_relative_output_dir(self, tmp_path):
+        """A relative scripts_dir must be resolved to an absolute path before
+        being embedded in the command — otherwise, once the agent's cwd
+        moves to scripts_dir.parent.parent, the same relative string gets
+        re-interpreted from there and points at the wrong, doubly-nested
+        location."""
+        eng = self._make_engineer(tmp_path, output_language="csharp")
+        eng.scripts_dir = Path("relative_output/scripts/run123")
+        tokens = shlex.split(eng._get_run_command())
+        project_arg = tokens[3]
+        assert Path(project_arg).is_absolute()
+        assert project_arg == str(eng.scripts_dir.resolve() / "ApiClient.csproj")
 
     def test_get_run_command_unknown(self, tmp_path):
         """Unknown language defaults to Python command."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -91,6 +91,16 @@ class TestLoadLanguagePartial:
         assert "Java program" in text
         assert "HttpClient" in text
         assert "/tmp/scripts/api_client.java" in text
+    def test_csharp_partial(self):
+        text = load_language_partial(
+            "csharp",
+            scripts_dir="/tmp/scripts",
+            client_filename="api_client.cs",
+            run_command="dotnet run",
+        )
+        assert "C# program" in text
+        assert "HttpClient" in text
+        assert "/tmp/scripts/api_client.cs" in text
 
 
 class TestEngineerTemplates:


### PR DESCRIPTION
Follows the exact same pattern as python/javascript/typescript:

- New prompt partial (prompts/partials/_language_csharp.md): uses System.Net.Http.HttpClient and System.Text.Json - both part of the .NET 5+ base class library, so no NuGet package is needed for HTTP or JSON (unlike Java, .NET's stdlib does include JSON support). Packaged as a minimal .csproj so `dotnet run` just works. Same auth-hardcoding/refresh guidance as the other languages. No filename vs. class-name naming workaround needed here (unlike Java) - C# doesn't require a public class's name to match its file's name.
- base_engineer.py: added "csharp" to _OUTPUT_LANGUAGE_EXTENSIONS (.cs), _get_language_name() ("C#"), _get_run_command() ("dotnet run"), and _get_auto_output_files() (ApiClient.csproj, always included - a project file is required to `dotnet run` regardless of dependencies, matching typescript's "always" precedent rather than javascript/go's conditional one).
- cli.py: added C# to the interactive `output_language` config picker.
- Updated the three docstrings/comments that listed the language set (config.py, engineer.py, prompts/__init__.py) and README.md's output language line.
- Tests: mirrored the existing per-language test pattern in test_base_engineer.py (extension, run command, prompt content) and test_prompts.py (partial loading) for C#.

Checked the partial for the literal-brace str.format_map() bug caught in the Java PR before writing this one - no literal `{`/`}` anywhere in the new file (confirmed via grep), since C# code snippets weren't needed to convey the guidance here.

Full test suite passes (49/49, run 3x) except the same pre-existing flaky test as the other language PRs
(test_existing_client_language_falls_back_to_newest_file - a mtime-resolution race condition, unrelated to this change, present on a clean main checkout too). ruff check is clean on every file this touches (8 pre-existing lint errors elsewhere on main, none in the touched lines).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds C# as a supported output language that generates a minimal .NET project and runs with a cwd‑independent `dotnet run --project` command. The run command resolves and shell‑quotes the project path so it works from any directory, including paths with shell metacharacters.

- **New Features**
  - `base_engineer`: maps `csharp` -> `.cs`, language "C#", run command `dotnet run --project {scripts_dir}/ApiClient.csproj` using `shlex.quote` and an absolute path, and always includes `ApiClient.csproj`.
  - New partial `prompts/partials/_language_csharp.md` using `HttpClient`/`System.Text.Json` (available since .NET Core 3.0), with auth hardcoding/refresh, save paths, and adaptive target framework guidance (default `net8.0`; adjust up or down to match the installed SDK).
  - CLI adds `csharp`; README/config/engineer/prompt docs updated.

- **Tests**
  - `tests/test_base_engineer.py`: asserts `.cs` extension; run command points to a resolved, safely quoted project path; handles metacharacters; resolves relative output dirs; C# prompt content included.
  - `tests/test_prompts.py`: verifies the C# partial loads and renders `run_command` and paths.

<sup>Written for commit 6306e3978ed66c6830254f2e92003332e4a65fec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds C# as a supported output language. The main changes are:

- C# prompt guidance using the .NET base class library.
- `.cs` and `.csproj` output handling.
- An absolute, shell-quoted `dotnet run --project` command.
- C# support in settings, documentation, and tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The run command now points directly to the generated project from any working directory.
- The target-framework guidance now handles installed SDK and runtime differences.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/base_engineer.py | Adds C# mappings, project output guidance, and a cwd-independent run command. |
| src/reverse_api/prompts/partials/_language_csharp.md | Adds C# generation, authentication, project setup, and target-framework guidance. |
| src/reverse_api/cli.py | Adds C# to the interactive output-language setting. |
| tests/test_base_engineer.py | Adds coverage for C# extensions, prompts, project paths, and shell quoting. |
| tests/test_prompts.py | Adds coverage for loading and rendering the C# prompt partial. |

<sub>Reviews (2): Last reviewed commit: ["Make the C# target-framework guidance di..."](https://github.com/kalil0321/reverse-api-engineer/commit/6306e3978ed66c6830254f2e92003332e4a65fec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46049251)</sub>

<!-- /greptile_comment -->