### PR TITLE
Make run/list language-aware and fix Windows run-command quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`run`/`list` now work for every output language**: `discover_scripts()` previously only found `.py` files, so `reverse-api-engineer run <run_id>` failed with "No Python scripts found" for JS/TS/Go/Java/C#/PHP/Ruby/C clients. Discovery now covers all supported extensions (excluding build dirs and the vendored cJSON sources), and the run command dispatches to the right toolchain per language (compile+execute for C), with a clear error when the required tool isn't on PATH.
+- **Windows-safe run-command quoting**: the Java/C#/PHP/Ruby/C run commands quoted paths with POSIX-only `shlex.quote`, which cmd.exe/PowerShell parse incorrectly for paths containing spaces. Paths are now quoted per-platform (`subprocess.list2cmdline` on Windows).
+
 ### Added
 - **Go output language**: `output_language: "go"` is now supported alongside python/javascript/typescript, generating a standard-library-first (`net/http`, `encoding/json`) Go program, with the same auth-hardcoding/refresh and bot-detection-fallback guidance as the other languages.
 - **Java output language**: `output_language: "java"` is now supported alongside python/javascript/typescript, generating a small Maven project using `java.net.http.HttpClient` (JDK 11+, no HTTP library dependency) and Gson for JSON, with the same auth-hardcoding/refresh guidance as the other languages.

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -480,7 +480,12 @@ class BaseEngineer(ABC):
 
         shlex.quote is POSIX-only: cmd.exe/PowerShell pass its single quotes
         through literally, so a spaced Windows path would break apart.
-        list2cmdline applies the double-quoting rules Windows shells parse.
+        list2cmdline applies the double-quoting rules cmd.exe/CreateProcess
+        parse. Known boundary: PowerShell still expands `$` and backtick
+        inside double quotes, and no quoting satisfies cmd.exe and PowerShell
+        simultaneously for such paths — cmd-safe is the chosen baseline, and
+        paths whose components contain `$`/backtick are not supported on
+        Windows.
         """
         if sys.platform == "win32":
             return subprocess.list2cmdline([str(path)])

--- a/src/reverse_api/base_engineer.py
+++ b/src/reverse_api/base_engineer.py
@@ -3,6 +3,8 @@
 import asyncio
 import os
 import shlex
+import subprocess
+import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
@@ -13,7 +15,13 @@ from .messages import MessageStore
 from .session import SessionManager
 from .sync import FileSyncWatcher, get_available_directory
 from .tui import THEME_PRIMARY, THEME_SECONDARY, ClaudeUI
-from .utils import generate_folder_name, get_docs_dir, get_history_path, get_scripts_dir
+from .utils import (
+    OUTPUT_LANGUAGE_EXTENSIONS,
+    generate_folder_name,
+    get_docs_dir,
+    get_history_path,
+    get_scripts_dir,
+)
 
 DEBUG = os.environ.get("DEBUG", "0") == "1"
 
@@ -30,17 +38,9 @@ NON_INTERACTIVE_ASK_USER_MESSAGE = (
 class BaseEngineer(ABC):
     """Abstract base class for API reverse engineering implementations."""
 
-    _OUTPUT_LANGUAGE_EXTENSIONS = {
-        "python": ".py",
-        "javascript": ".js",
-        "typescript": ".ts",
-        "go": ".go",
-        "java": ".java",
-        "csharp": ".cs",
-        "php": ".php",
-        "ruby": ".rb",
-        "c": ".c",
-    }
+    # Single source of truth lives in utils.OUTPUT_LANGUAGE_EXTENSIONS so
+    # script discovery and the run command dispatch stay in sync with codegen.
+    _OUTPUT_LANGUAGE_EXTENSIONS = OUTPUT_LANGUAGE_EXTENSIONS
 
     def __init__(
         self,
@@ -474,6 +474,18 @@ class BaseEngineer(ABC):
             return "openapi.json"
         return f"api_client{self._get_output_extension()}"
 
+    @staticmethod
+    def _quote_path(path) -> str:
+        """Shell-quote a path for the platform's default shell.
+
+        shlex.quote is POSIX-only: cmd.exe/PowerShell pass its single quotes
+        through literally, so a spaced Windows path would break apart.
+        list2cmdline applies the double-quoting rules Windows shells parse.
+        """
+        if sys.platform == "win32":
+            return subprocess.list2cmdline([str(path)])
+        return shlex.quote(str(path))
+
     def _get_run_command(self) -> str:
         """Return the command to run the generated client."""
         if self.output_language == "java":
@@ -495,7 +507,7 @@ class BaseEngineer(ABC):
             # exec:java invokes main() reflectively in-process, which fails
             # on the package-private ApiClient class the Java partial
             # requires ("symbolic reference class is not accessible").
-            pom = shlex.quote(str(self.scripts_dir.resolve() / "pom.xml"))
+            pom = self._quote_path(str(self.scripts_dir.resolve() / "pom.xml"))
             return f"mvn -q -f {pom} compile exec:exec"
         if self.output_language == "csharp":
             # Unlike python/node/npx (which happily take a plain relative
@@ -512,7 +524,7 @@ class BaseEngineer(ABC):
             # re-interpreted against the agent's cwd (scripts_dir.parent.
             # parent) instead of the original cwd it was relative to,
             # pointing --project at the wrong, doubly-nested location.
-            csproj = shlex.quote(str(self.scripts_dir.resolve() / "ApiClient.csproj"))
+            csproj = self._quote_path(str(self.scripts_dir.resolve() / "ApiClient.csproj"))
             return f"dotnet run --project {csproj}"
         if self.output_language == "php":
             # Full path, not a bare relative "php api_client.php": the
@@ -532,7 +544,7 @@ class BaseEngineer(ABC):
             # re-interpreted against the agent's cwd (scripts_dir.parent.
             # parent) instead of the original cwd it was relative to,
             # pointing this command at the wrong, doubly-nested location.
-            path = shlex.quote(str(self.scripts_dir.resolve() / self._get_client_filename()))
+            path = self._quote_path(str(self.scripts_dir.resolve() / self._get_client_filename()))
             return f"php {path}"
         if self.output_language == "ruby":
             # Full path, not a bare relative "ruby api_client.rb": the
@@ -546,7 +558,7 @@ class BaseEngineer(ABC):
             # re-interpreted against the agent's cwd (scripts_dir.parent.
             # parent) instead of the original cwd it was relative to,
             # pointing this command at the wrong, doubly-nested location.
-            path = shlex.quote(str(self.scripts_dir.resolve() / self._get_client_filename()))
+            path = self._quote_path(str(self.scripts_dir.resolve() / self._get_client_filename()))
             return f"ruby {path}"
         if self.output_language == "c":
             # Unlike every other language here, C needs an explicit compile
@@ -562,9 +574,9 @@ class BaseEngineer(ABC):
             # dir.parent.parent) instead of the original cwd it was relative
             # to, pointing all three at the wrong, doubly-nested location.
             resolved = self.scripts_dir.resolve()
-            source = shlex.quote(str(resolved / self._get_client_filename()))
-            cjson = shlex.quote(str(resolved / "cJSON.c"))
-            binary = shlex.quote(str(resolved / "api_client"))
+            source = self._quote_path(str(resolved / self._get_client_filename()))
+            cjson = self._quote_path(str(resolved / "cJSON.c"))
+            binary = self._quote_path(str(resolved / "api_client"))
             return f"cc {source} {cjson} -lcurl -o {binary} && {binary}"
         return {
             "python": "python api_client.py",

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2663,6 +2663,27 @@ def _extract_missing_module(stderr: str) -> str | None:
     return missing
 
 
+def _run_non_python_script(script, script_args) -> None:
+    """Run a non-Python generated client with its language's toolchain and exit."""
+    import shutil
+    import subprocess
+
+    from .utils import build_script_commands
+
+    try:
+        steps, tool = build_script_commands(script, script_args)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    if shutil.which(tool) is None:
+        raise click.ClickException(f"'{tool}' not found on PATH (required to run {script.name})")
+    returncode = 0
+    for cmd in steps:
+        returncode = subprocess.run(cmd, cwd=str(script.parent)).returncode
+        if returncode != 0:
+            break
+    raise SystemExit(returncode)
+
+
 def _run_script_machine_payload(
     *,
     identifier: str,
@@ -2691,7 +2712,7 @@ def _run_script_machine_payload(
                 identifier=identifier,
                 run_id=run_id,
                 scripts=scripts,
-                error=f"No Python scripts found for run {run_id}",
+                error=f"No runnable scripts found for run {run_id}",
                 error_kind_hint="engine_failure",
             )
 
@@ -2728,6 +2749,50 @@ def _run_script_machine_payload(
             )
 
         emit_event("script_selected", run_id=run_id, script_path=str(script))
+
+        if script.suffix != ".py":
+            import shutil
+
+            from .utils import build_script_commands
+
+            try:
+                steps, tool = build_script_commands(script, script_args)
+            except ValueError as e:
+                return _build_run_payload(
+                    identifier=identifier,
+                    run_id=run_id,
+                    script_path=str(script),
+                    script_args=script_args,
+                    scripts=scripts,
+                    error=str(e),
+                    error_kind_hint="misuse",
+                )
+            if shutil.which(tool) is None:
+                return _build_run_payload(
+                    identifier=identifier,
+                    run_id=run_id,
+                    script_path=str(script),
+                    script_args=script_args,
+                    scripts=scripts,
+                    error=f"'{tool}' not found on PATH (required to run {script.name})",
+                    error_kind_hint="config_invalid",
+                )
+            result = None
+            for cmd in steps:
+                emit_event("process_started", run_id=run_id, script_path=str(script))
+                result = subprocess.run(cmd, cwd=str(script.parent), capture_output=True, text=True)
+                if result.returncode != 0:
+                    break
+            return _build_run_payload(
+                identifier=identifier,
+                run_id=run_id,
+                script_path=str(script),
+                script_args=script_args,
+                returncode=result.returncode,
+                stdout=result.stdout or "",
+                stderr=result.stderr or "",
+                scripts=scripts,
+            )
 
         from .utils import get_base_output_dir as _get_base
 
@@ -2930,7 +2995,7 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts, no_interac
         console.print(f"{scripts[0].parent}", style="dim")
 
     if not scripts:
-        console.print(f"[red]No Python scripts found for run {run_id}[/red]")
+        console.print(f"[red]No runnable scripts found for run {run_id}[/red]")
         raise SystemExit(1)
 
     # --ls: just list and exit
@@ -2973,6 +3038,10 @@ def run_script(ctx, identifier, script_args, file_name, list_scripts, no_interac
         ).ask()
         if script is None:
             raise click.Abort()
+
+    # Non-Python clients: dispatch on extension, no venv involved
+    if script.suffix != ".py":
+        _run_non_python_script(script, script_args)
 
     # Shared venv at ~/.reverse-api/runs/.venv (with requests pre-installed)
     from .utils import get_base_output_dir as _get_base

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -2675,7 +2675,7 @@ def _run_non_python_script(script, script_args) -> None:
     except ValueError as e:
         raise click.ClickException(str(e)) from e
     if shutil.which(tool) is None:
-        raise click.ClickException(f"'{tool}' not found on PATH (required to run {script.name})")
+        raise click.ClickException(f"cannot run {script.name}: '{tool}' is missing from PATH — install it and retry")
     returncode = 0
     for cmd in steps:
         returncode = subprocess.run(cmd, cwd=str(script.parent)).returncode
@@ -2774,7 +2774,7 @@ def _run_script_machine_payload(
                     script_path=str(script),
                     script_args=script_args,
                     scripts=scripts,
-                    error=f"'{tool}' not found on PATH (required to run {script.name})",
+                    error=f"cannot run {script.name}: '{tool}' is missing from PATH — install it and retry",
                     error_kind_hint="config_invalid",
                 )
             result = None

--- a/src/reverse_api/prompts/partials/_language_c.md
+++ b/src/reverse_api/prompts/partials/_language_c.md
@@ -8,6 +8,7 @@
 - Reuse one `CURL` handle across requests rather than creating a new one per call
 - Create a separate function for each distinct API endpoint, with a small struct for its response shape
 - Check every `libcurl`/allocation return value; don't ignore errors
+- Keep the code warning-clean under `-Wall -Wextra` — no unused parameters or variables
 - Include a `main` function with example usage
 
 **Authentication & credentials:**

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -691,16 +691,19 @@ def discover_scripts(run_id: str, output_dir: str | None = None, run_metadata: d
     if not scripts_dir.exists():
         return []
 
-    exclude_dirs = {"__pycache__", ".venv", "node_modules", "bin", "obj", "target"}
     # Support files that share a script extension but are never the client
     # itself: package markers and the vendored cJSON library (C output).
+    # Build/venv directories (__pycache__, .venv, node_modules, bin, obj,
+    # target) need no explicit filter: iterdir() doesn't recurse, and
+    # matching names in *parent* components (e.g. a custom output_dir under
+    # /tmp/target) must not exclude anything.
     exclude_files = {"__init__.py", "cJSON.c", "cJSON.h"}
 
-    scripts = []
-    for f in scripts_dir.iterdir():
-        if f.is_file() and f.suffix in SCRIPT_EXTENSIONS and f.name not in exclude_files:
-            scripts.append(f)
-    scripts = [s for s in scripts if not any(part in exclude_dirs for part in s.parts)]
+    scripts = [
+        f
+        for f in scripts_dir.iterdir()
+        if f.is_file() and f.suffix in SCRIPT_EXTENSIONS and f.name not in exclude_files
+    ]
 
     return sorted(scripts, key=lambda p: p.name)
 
@@ -726,6 +729,10 @@ def build_script_commands(script: Path, script_args: tuple[str, ...] = ()) -> tu
         ValueError: For unsupported extensions, or script_args with a Java
             client (mvn exec's program arguments are fixed in the pom).
     """
+    # Resolve before building argv: callers run these with cwd=script.parent,
+    # and a relative script path (from a relative output_dir) would otherwise
+    # be re-resolved by the child against that new cwd and fail to start.
+    script = script.resolve()
     d = script.parent
     suffix = script.suffix
     if suffix == ".js":

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -11,6 +11,23 @@ import httpx
 
 from . import __version__
 
+# One entry per supported output language. BaseEngineer's extension map is
+# built from this, and discover_scripts()/build_script_commands() key off the
+# extensions, so adding a language here is the single required registration.
+OUTPUT_LANGUAGE_EXTENSIONS = {
+    "python": ".py",
+    "javascript": ".js",
+    "typescript": ".ts",
+    "go": ".go",
+    "java": ".java",
+    "csharp": ".cs",
+    "php": ".php",
+    "ruby": ".rb",
+    "c": ".c",
+}
+
+SCRIPT_EXTENSIONS = frozenset(OUTPUT_LANGUAGE_EXTENSIONS.values())
+
 
 def check_for_updates() -> str | None:
     """Check PyPI for newer version.
@@ -631,7 +648,7 @@ def resolve_run(identifier: str, session_manager, *, interactive: bool = True) -
 
 
 def discover_scripts(run_id: str, output_dir: str | None = None, run_metadata: dict | None = None) -> list[Path]:
-    """Find all executable Python scripts in a run's script directory.
+    """Find all runnable generated scripts in a run's script directory.
 
     Tries the stored script path from run metadata first, then falls back
     to the current output_dir config.
@@ -642,7 +659,9 @@ def discover_scripts(run_id: str, output_dir: str | None = None, run_metadata: d
         run_metadata: Optional run dict with paths.script_path to resolve from
 
     Returns:
-        Sorted list of .py file Paths (excludes __pycache__, .venv, __init__.py)
+        Sorted list of script Paths in any supported output language
+        (excludes build/venv directories and support files like __init__.py
+        and the vendored cJSON sources)
 
     Raises:
         ValueError: If run_id contains invalid characters
@@ -672,16 +691,74 @@ def discover_scripts(run_id: str, output_dir: str | None = None, run_metadata: d
     if not scripts_dir.exists():
         return []
 
-    exclude_dirs = {"__pycache__", ".venv"}
-    exclude_files = {"__init__.py"}
+    exclude_dirs = {"__pycache__", ".venv", "node_modules", "bin", "obj", "target"}
+    # Support files that share a script extension but are never the client
+    # itself: package markers and the vendored cJSON library (C output).
+    exclude_files = {"__init__.py", "cJSON.c", "cJSON.h"}
 
     scripts = []
     for f in scripts_dir.iterdir():
-        if f.is_file() and f.suffix == ".py" and f.name not in exclude_files:
+        if f.is_file() and f.suffix in SCRIPT_EXTENSIONS and f.name not in exclude_files:
             scripts.append(f)
     scripts = [s for s in scripts if not any(part in exclude_dirs for part in s.parts)]
 
     return sorted(scripts, key=lambda p: p.name)
+
+
+def build_script_commands(script: Path, script_args: tuple[str, ...] = ()) -> tuple[list[list[str]], str]:
+    """Build the subprocess command(s) that run a non-Python generated client.
+
+    Python clients are executed by the caller's shared-venv flow and are not
+    handled here. Commands use absolute paths so they work from any cwd; run
+    them with cwd=script.parent so relative artifacts (cookie jars, build
+    output) land next to the script.
+
+    Args:
+        script: Path to the client script (any supported non-.py extension)
+        script_args: Extra arguments to pass through to the client
+
+    Returns:
+        (steps, tool): ordered argv lists to run (C compiles then executes,
+        everything else is a single step) and the executable that must be on
+        PATH for them to work.
+
+    Raises:
+        ValueError: For unsupported extensions, or script_args with a Java
+            client (mvn exec's program arguments are fixed in the pom).
+    """
+    d = script.parent
+    suffix = script.suffix
+    if suffix == ".js":
+        return [["node", str(script), *script_args]], "node"
+    if suffix == ".ts":
+        return [["npx", "tsx", str(script), *script_args]], "npx"
+    if suffix == ".go":
+        return [["go", "run", str(script), *script_args]], "go"
+    if suffix == ".java":
+        if script_args:
+            raise ValueError(
+                "script arguments are not supported for Java clients: "
+                "mvn exec:exec's program arguments are fixed in the pom.xml"
+            )
+        return [["mvn", "-q", "-f", str(d / "pom.xml"), "compile", "exec:exec"]], "mvn"
+    if suffix == ".cs":
+        cmd = ["dotnet", "run", "--project", str(d / "ApiClient.csproj")]
+        if script_args:
+            cmd += ["--", *script_args]
+        return [cmd], "dotnet"
+    if suffix == ".php":
+        return [["php", str(script), *script_args]], "php"
+    if suffix == ".rb":
+        return [["ruby", str(script), *script_args]], "ruby"
+    if suffix == ".c":
+        binary = d / script.stem
+        compile_cmd = ["cc", str(script)]
+        cjson = d / "cJSON.c"
+        if cjson.exists():
+            compile_cmd.append(str(cjson))
+        compile_cmd += ["-lcurl", "-o", str(binary)]
+        return [compile_cmd, [str(binary), *script_args]], "cc"
+    raise ValueError(f"unsupported script type: {script.name}")
 
 
 def extract_domain_from_har(har_path: Path) -> str | None:

--- a/tests/test_base_engineer.py
+++ b/tests/test_base_engineer.py
@@ -432,6 +432,24 @@ class TestBaseEngineerHelpers:
         eng = self._make_engineer(tmp_path, output_language="rust")
         assert eng._get_run_command() == "python api_client.py"
 
+    def test_quote_path_posix(self, monkeypatch):
+        """POSIX platforms use shlex.quote (single quotes for spaces)."""
+        from reverse_api import base_engineer as be
+
+        monkeypatch.setattr(be.sys, "platform", "linux")
+        from reverse_api.base_engineer import BaseEngineer
+
+        assert BaseEngineer._quote_path("/tmp/my dir/pom.xml") == "'/tmp/my dir/pom.xml'"
+
+    def test_quote_path_windows(self, monkeypatch):
+        """Windows uses list2cmdline double-quoting that cmd.exe/PowerShell parse."""
+        from reverse_api import base_engineer as be
+
+        monkeypatch.setattr(be.sys, "platform", "win32")
+        from reverse_api.base_engineer import BaseEngineer
+
+        assert BaseEngineer._quote_path(r"C:\Users\John Smith\pom.xml") == '"C:\\Users\\John Smith\\pom.xml"'
+
 
 class TestBaseEngineerBuildPrompt:
     """Test _build_analysis_prompt method."""

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -251,6 +251,44 @@ class TestDiscoverScripts:
         with pytest.raises(ValueError, match="too long"):
             discover_scripts("a" * 65)
 
+    def test_finds_all_language_extensions(self, scripts_dir_empty, tmp_path):
+        for name in [
+            "api_client.py", "api_client.js", "api_client.ts", "api_client.go",
+            "api_client.java", "api_client.cs", "api_client.php",
+            "api_client.rb", "api_client.c",
+        ]:
+            (scripts_dir_empty / name).write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert len(scripts) == 9
+
+    def test_excludes_vendored_cjson(self, scripts_dir_empty, tmp_path):
+        (scripts_dir_empty / "api_client.c").write_text("")
+        (scripts_dir_empty / "cJSON.c").write_text("")
+        (scripts_dir_empty / "cJSON.h").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert [s.name for s in scripts] == ["api_client.c"]
+
+    def test_excludes_build_dirs(self, scripts_dir_empty, tmp_path):
+        (scripts_dir_empty / "api_client.cs").write_text("")
+        for d in ["node_modules", "bin", "obj", "target"]:
+            sub = scripts_dir_empty / d
+            sub.mkdir()
+            (sub / "generated.cs").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert [s.name for s in scripts] == ["api_client.cs"]
+
+    def test_excludes_non_script_support_files(self, scripts_dir_empty, tmp_path):
+        (scripts_dir_empty / "api_client.java").write_text("")
+        (scripts_dir_empty / "pom.xml").write_text("")
+        (scripts_dir_empty / "go.mod").write_text("")
+        (scripts_dir_empty / "ApiClient.csproj").write_text("")
+        with patch("reverse_api.utils.get_base_output_dir", return_value=tmp_path):
+            scripts = discover_scripts("abc123def456")
+        assert [s.name for s in scripts] == ["api_client.java"]
+
 
 class TestDiscoverScriptsRunMetadata:
     """Test discover_scripts with run_metadata (stored path) fallback."""
@@ -361,7 +399,7 @@ class TestRunCommandLs:
         from reverse_api.cli import main
         result = cli_runner.invoke(main, ["run", "111222333444", "--ls"])
         assert result.exit_code == 1
-        assert "No Python scripts" in result.output
+        assert "No runnable scripts" in result.output
 
     def test_ls_with_fuzzy_name(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
@@ -461,7 +499,7 @@ class TestRunCommandNoScripts:
         from reverse_api.cli import main
         result = cli_runner.invoke(main, ["run", "111222333444"])
         assert result.exit_code == 1
-        assert "No Python scripts" in result.output
+        assert "No runnable scripts" in result.output
 
     def test_no_scripts_shows_prompt_preview(self, cli_runner, mock_cli_env):
         from reverse_api.cli import main
@@ -684,3 +722,88 @@ class TestExtractMissingModule:
         from reverse_api.cli import _extract_missing_module
         stderr = "ModuleNotFoundError: No module named 'requests\n'"
         assert _extract_missing_module(stderr) is None
+
+
+# ---------------------------------------------------------------------------
+# build_script_commands tests
+# ---------------------------------------------------------------------------
+
+class TestBuildScriptCommands:
+    """Test per-language command dispatch for the run subcommand."""
+
+    def test_javascript(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.js"
+        steps, tool = build_script_commands(script)
+        assert steps == [["node", str(script)]]
+        assert tool == "node"
+
+    def test_typescript(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.ts"
+        steps, tool = build_script_commands(script, ("--flag",))
+        assert steps == [["npx", "tsx", str(script), "--flag"]]
+        assert tool == "npx"
+
+    def test_go(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.go"
+        steps, tool = build_script_commands(script)
+        assert steps == [["go", "run", str(script)]]
+        assert tool == "go"
+
+    def test_java(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.java"
+        steps, tool = build_script_commands(script)
+        assert steps == [["mvn", "-q", "-f", str(tmp_path / "pom.xml"), "compile", "exec:exec"]]
+        assert tool == "mvn"
+
+    def test_java_rejects_script_args(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        with pytest.raises(ValueError, match="not supported for Java"):
+            build_script_commands(tmp_path / "api_client.java", ("--x",))
+
+    def test_csharp_passes_args_after_separator(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.cs"
+        steps, tool = build_script_commands(script, ("--x",))
+        assert steps == [["dotnet", "run", "--project", str(tmp_path / "ApiClient.csproj"), "--", "--x"]]
+        assert tool == "dotnet"
+
+    def test_php(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.php"
+        steps, tool = build_script_commands(script)
+        assert steps == [["php", str(script)]]
+        assert tool == "php"
+
+    def test_ruby(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.rb"
+        steps, tool = build_script_commands(script)
+        assert steps == [["ruby", str(script)]]
+        assert tool == "ruby"
+
+    def test_c_compiles_then_runs_with_vendored_cjson(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.c"
+        (tmp_path / "cJSON.c").write_text("")
+        steps, tool = build_script_commands(script, ("--x",))
+        binary = str(tmp_path / "api_client")
+        assert steps == [
+            ["cc", str(script), str(tmp_path / "cJSON.c"), "-lcurl", "-o", binary],
+            [binary, "--x"],
+        ]
+        assert tool == "cc"
+
+    def test_c_without_cjson(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        script = tmp_path / "api_client.c"
+        steps, _ = build_script_commands(script)
+        assert steps[0] == ["cc", str(script), "-lcurl", "-o", str(tmp_path / "api_client")]
+
+    def test_unsupported_extension_raises(self, tmp_path):
+        from reverse_api.utils import build_script_commands
+        with pytest.raises(ValueError, match="unsupported script type"):
+            build_script_commands(tmp_path / "api_client.xyz")

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -280,6 +280,16 @@ class TestDiscoverScripts:
             scripts = discover_scripts("abc123def456")
         assert [s.name for s in scripts] == ["api_client.cs"]
 
+    def test_output_dir_under_build_dir_name_still_discovers(self, tmp_path):
+        """A custom output_dir whose *parent* path contains a build-dir name
+        (e.g. /tmp/target/...) must not exclude the run's scripts."""
+        out = tmp_path / "target" / "myout"
+        d = out / "scripts" / "run1"
+        d.mkdir(parents=True)
+        (d / "api_client.go").write_text("")
+        scripts = discover_scripts("run1", output_dir=str(out))
+        assert [s.name for s in scripts] == ["api_client.go"]
+
     def test_excludes_non_script_support_files(self, scripts_dir_empty, tmp_path):
         (scripts_dir_empty / "api_client.java").write_text("")
         (scripts_dir_empty / "pom.xml").write_text("")
@@ -807,6 +817,18 @@ class TestBuildScriptCommands:
         from reverse_api.utils import build_script_commands
         with pytest.raises(ValueError, match="unsupported script type"):
             build_script_commands(tmp_path / "api_client.xyz")
+
+    def test_relative_script_path_resolved_to_absolute(self, tmp_path, monkeypatch):
+        """Relative script paths (from a relative output_dir) must become
+        absolute in the argv: callers run with cwd=script.parent, which would
+        otherwise re-anchor the relative path and fail to start."""
+        from reverse_api.utils import build_script_commands
+        monkeypatch.chdir(tmp_path)
+        d = Path("out") / "scripts" / "run1"
+        d.mkdir(parents=True)
+        script = d / "api_client.js"
+        steps, _ = build_script_commands(script)
+        assert steps == [["node", str(tmp_path.resolve() / d / "api_client.js")]]
 
     def test_paths_with_spaces_stay_intact_in_argv(self, tmp_path):
         """argv lists are passed to subprocess without a shell, so spaced

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -807,3 +807,13 @@ class TestBuildScriptCommands:
         from reverse_api.utils import build_script_commands
         with pytest.raises(ValueError, match="unsupported script type"):
             build_script_commands(tmp_path / "api_client.xyz")
+
+    def test_paths_with_spaces_stay_intact_in_argv(self, tmp_path):
+        """argv lists are passed to subprocess without a shell, so spaced
+        paths must survive as single arguments — no quoting layer involved."""
+        from reverse_api.utils import build_script_commands
+        d = tmp_path / "my scripts"
+        d.mkdir()
+        script = d / "api_client.php"
+        steps, _ = build_script_commands(script)
+        assert steps == [["php", str(script)]]


### PR DESCRIPTION
Fixes the outstanding issues found while testing the six output-language PRs (#100–#105).

## 1. `run`/`list` were Python-only (found on #100, affected every language)
`discover_scripts()` only globbed `.py`, so `reverse-api-engineer run <run_id>` failed with "No Python scripts found" for JS/TS/Go/Java/C#/PHP/Ruby/C clients, and the run path always executed the shared-venv Python interpreter.

- Discovery now covers all supported extensions, with the language→extension map moved to `utils.OUTPUT_LANGUAGE_EXTENSIONS` as the single source of truth (`BaseEngineer` reuses it), and excludes build dirs (`node_modules`, `bin`, `obj`, `target`) and the vendored `cJSON.c`/`cJSON.h`.
- `build_script_commands()` dispatches per language: `node` / `npx tsx` / `go run` / `mvn -q -f pom.xml compile exec:exec` / `dotnet run --project` / `php` / `ruby`, and compile-then-execute for C. Missing toolchains produce a clear error naming the required binary instead of a crash. Java rejects extra script args explicitly (mvn exec's program args are fixed in the pom); C# passes them after `--`.
- Both the machine (`--json`/`--json-stream`) and interactive run paths use the dispatch; the Python venv flow is unchanged.

## 2. Windows quoting (flagged on #101–#105)
The Java/C#/PHP/Ruby/C run commands quoted paths with POSIX-only `shlex.quote`, which cmd.exe/PowerShell parse incorrectly for paths containing spaces. `BaseEngineer._quote_path()` now uses `subprocess.list2cmdline` on Windows and `shlex.quote` elsewhere.

## 3. C compiler warnings (found on #105, minor)
The C partial now asks for `-Wall -Wextra`-clean code — the live-tested client had unused-parameter warnings.

## Testing
- 771 tests pass (21 new: multi-language discovery, cJSON/build-dir exclusion, per-language command dispatch).
- ruff: exactly the 19 pre-existing findings on the touched files, none new.
- Verified live against real clients generated during the #100–#105 testing sessions: `run --json` executed the Go, PHP, C (compile step included), C#, and Ruby clients end-to-end with exit 0. (The Java run surfaced a runtime fragility in that one generated artifact's second example call — the dispatch itself correctly ran Maven and propagated the exit code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpXzPMFT1X8YCZQcxaFYVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `run` and `list` work across all output languages and fix Windows path quoting so commands run reliably. Discovery is now robust across directories, and commands use absolute paths to run correctly from any working directory.

- **Bug Fixes**
  - Script discovery covers all supported extensions and ignores support files (`cJSON.*`, `__init__.py`). It no longer misfires when parent paths contain build-dir names; `utils.OUTPUT_LANGUAGE_EXTENSIONS` is the single source of truth.
  - Run dispatch is per language (`node`, `npx tsx`, `go run`, `mvn -q -f pom.xml compile exec:exec`, `dotnet run --project`, `php`, `ruby`; C compiles then runs). Commands use absolute paths and run with `cwd=script.parent`. Clear missing-tool errors; in machine mode they are `config_invalid`. Java rejects extra args; C# forwards args after `--`.
  - Windows-safe quoting for run commands: uses `subprocess.list2cmdline` on Windows and `shlex.quote` elsewhere. Documented PowerShell `$`/backtick limits; cmd.exe-safe quoting is the baseline.
  - CLI copy now says “No runnable scripts” when nothing is found.

<sup>Written for commit 21fc967e38601d55874027b27340204e61c061c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes script discovery and execution aware of every supported output language. The main changes are:

- Centralized language-to-extension mappings.
- Added toolchain-specific commands for non-Python clients.
- Added platform-specific quoting for generated run commands.
- Expanded discovery and command-building tests.
- Updated C generation guidance to avoid compiler warnings.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small PowerShell quoting cleanup.

- Language-specific execution uses argv lists and clear tool checks.
- Known generated support files are excluded from discovery.
- PowerShell metacharacters in generated command paths can still be interpreted by the shell.

src/reverse_api/base_engineer.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/base_engineer.py | Reuses the centralized extension map and adds Windows path quoting, but the quoting does not safely cover PowerShell metacharacters. |
| src/reverse_api/cli.py | Routes non-Python clients through language-specific subprocess commands in interactive and machine-readable modes. |
| src/reverse_api/utils.py | Adds shared extension constants, multilingual script discovery, and argv-based command construction for each supported toolchain. |
| tests/test_run_command.py | Adds broad discovery and command-construction coverage, without Windows shell-specific path cases. |
| src/reverse_api/prompts/partials/_language_c.md | Adds guidance for warning-clean generated C code. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/reverse_api/base_engineer.py:485-486
**PowerShell Paths Remain Unsafe**

`list2cmdline()` applies Windows C-runtime/cmd.exe quoting, but the returned text is interpolated into a shell command that may run in PowerShell. A valid path containing PowerShell metacharacters such as `$` or a backtick can therefore be expanded or escaped, causing the generated run command to use the wrong path or fail.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Make run/list language-aware and quote r..."](https://github.com/kalil0321/reverse-api-engineer/commit/6544087f2fee2e1a1659e25b290a5eb40cc485aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46266655)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->