### PR TITLE
[codex] Add Ollama support through OpenCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **OpenCode setup**: RAE now reuses an existing server or downloads/starts `opencode-ai@latest` through `npx` without requiring a global OpenCode install, with configurable auto-start, package, and base URL settings plus password inheritance. Fresh configurations default to free `opencode/big-pickle`. Provider/model pairs are validated before session creation, invalid configurations include current free-model suggestions, and older compatible servers show an upgrade warning. `/settings` shows a loading spinner, uses a live searchable provider/model picker, saves the pair atomically, and remains open across related changes until Back is selected.
+- **Ollama setup**: OpenCode mode can discover tool-capable Ollama models, start an installed daemon, and inject provider configuration without modifying the user's `opencode.json`.
 
 ### Fixed
 - **OpenCode permissions**: Permission V2 events now reply through OpenCode's current, non-deprecated permission endpoint while retaining compatibility with older servers.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Settings live in `~/.reverse-api/config.json` and can be edited via `/settings` 
   "agent_browser_notes": "",
   "claude_code_model": "claude-sonnet-4-6",
   "collector_model": "claude-sonnet-4-6",
+  "ollama_auto_start": true,
+  "ollama_base_url": "http://127.0.0.1:11434",
   "opencode_auto_start": true,
   "opencode_base_url": "http://127.0.0.1:4096",
   "opencode_model": "big-pickle",
@@ -100,6 +102,7 @@ Settings live in `~/.reverse-api/config.json` and can be edited via `/settings` 
 - **Models**: Sonnet 4.6 (default), Opus 4.6 (most capable), Haiku 4.5 (fastest). For OpenCode see [models.dev](https://models.dev).
 - **SDK**: `claude` (default), `opencode`, `cursor`, or `copilot` (GitHub Copilot).
 - **OpenCode setup**: with `sdk: "opencode"`, RAE reuses an existing server or downloads/starts `opencode-ai@latest` through `npx`; a global OpenCode installation is not required. Fresh configurations default to the free `opencode/big-pickle` model. `/settings` shows a loading spinner, then offers a searchable **OpenCode Provider / Model** picker populated from the server's connected, tool-capable catalog and marks free OpenCode options. Before creating a session, RAE validates the saved pair again and suggests currently available free models when configuration is invalid. Compatible older servers are reused with a version warning. Node.js 20+ is required for automatic startup. Password-protected servers use `OPENCODE_SERVER_PASSWORD` and optional `OPENCODE_SERVER_USERNAME`. Override startup with `OPENCODE_BASE_URL`, `RAE_OPENCODE_PACKAGE`, or `RAE_OPENCODE_AUTO_START=0`.
+- **Ollama through OpenCode**: choose provider `ollama` in `/settings`; RAE starts an installed Ollama daemon if needed, lists only installed models with tool calling and 64k+ context, and supplies OpenCode's provider config inline. Models are never downloaded silently. Override with `RAE_OLLAMA_BASE_URL` or `RAE_OLLAMA_AUTO_START=0`.
 - **Output language**: `python`, `javascript`, `typescript`, `go`, `java`, `csharp`, `php`, `ruby`, or `c`. C needs a POSIX toolchain (`cc`, libcurl headers) — macOS/Linux, or WSL/MSYS2 on Windows.
 
 ## CLI

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -56,6 +56,58 @@ config_manager = ConfigManager(get_config_path())
 session_manager = SessionManager(get_history_path())
 
 
+def _format_ollama_size(size: int) -> str:
+    if size < 1024:
+        return "cloud"
+    return f"{size / (1024**3):.1f} GB"
+
+
+def _select_ollama_model_for_settings() -> str | None:
+    """Discover installed agent-capable Ollama models and let the user choose."""
+
+    from .ollama_runtime import OllamaSetupError, ensure_ollama_models
+
+    try:
+        status = asyncio.run(ensure_ollama_models())
+    except OllamaSetupError as e:
+        console.print(f" [yellow]error:[/yellow] {e}\n")
+        return None
+
+    models = status.compatible_models
+    if not models:
+        console.print(" [yellow]error:[/yellow] no installed Ollama model supports tools with at least 64k context")
+        console.print(" [dim]Pull a compatible model explicitly, then retry. RAE will not download multi-GB models silently.[/dim]\n")
+        return None
+    if len(models) == 1:
+        console.print(f" [dim]using the only compatible Ollama model: {models[0].name}[/dim]")
+        return models[0].name
+
+    choices = [
+        Choice(
+            title=(
+                f"{model.name}  ({model.parameter_size or 'unknown'}, {_format_ollama_size(model.size)}, "
+                f"{model.context_length // 1024}k context)"
+            ),
+            value=model.name,
+        )
+        for model in models
+    ]
+    choices.append(Choice(title="back", value="back"))
+    selected = questionary.select(
+        " > ollama model",
+        choices=choices,
+        pointer=">",
+        qmark="",
+        style=questionary.Style(
+            [
+                ("pointer", f"fg:{THEME_SECONDARY} bold"),
+                ("highlighted", f"fg:{THEME_SECONDARY} bold"),
+            ]
+        ),
+    ).ask()
+    return None if selected in {None, "back"} else str(selected)
+
+
 def default_model_for_configured_sdk(sdk: str | None = None) -> str:
     """Return the configured default model id for the given SDK (or current config SDK)."""
     s = (sdk or config_manager.get("sdk", "claude") or "claude").lower()
@@ -113,10 +165,6 @@ def _select_opencode_pair_for_settings(mode_color=THEME_PRIMARY) -> tuple[str, s
         if provider.get("id") and isinstance(models, dict) and any(opencode_model_is_selectable(model) for model in models.values()):
             selectable.append(provider)
 
-    if not selectable:
-        console.print(" [yellow]error:[/yellow] OpenCode reported no connected providers with tool-capable models.\n")
-        return None
-
     style = questionary.Style(
         [
             ("pointer", f"fg:{mode_color} bold"),
@@ -134,8 +182,11 @@ def _select_opencode_pair_for_settings(mode_color=THEME_PRIMARY) -> tuple[str, s
             else provider_id
         )
         provider_choices.append(Choice(title=title, value=provider_id))
-    provider_choices.append(Choice(title="back", value="back"))
     provider_ids = {str(provider["id"]) for provider in selectable}
+    if "ollama" not in provider_ids:
+        provider_choices.append(Choice(title="ollama — installed local models", value="ollama"))
+        provider_ids.add("ollama")
+    provider_choices.append(Choice(title="back", value="back"))
     provider_id = questionary.select(
         " > opencode provider",
         choices=provider_choices,
@@ -148,6 +199,9 @@ def _select_opencode_pair_for_settings(mode_color=THEME_PRIMARY) -> tuple[str, s
     ).ask()
     if provider_id is None or provider_id == "back":
         return None
+    if provider_id == "ollama":
+        model_id = _select_ollama_model_for_settings()
+        return ("ollama", model_id) if model_id else None
 
     provider = next(item for item in selectable if item.get("id") == provider_id)
     models = provider["models"]

--- a/src/reverse_api/config.py
+++ b/src/reverse_api/config.py
@@ -25,6 +25,8 @@ DEFAULT_CONFIG = {
     "opencode_auto_start": True,
     "opencode_base_url": "http://127.0.0.1:4096",
     "opencode_npx_package": "opencode-ai@latest",
+    "ollama_auto_start": True,
+    "ollama_base_url": "http://127.0.0.1:11434",
     "output_dir": None,  # None means use ~/.reverse-api/runs
     "output_language": "python",  # "python", "javascript", "typescript", "go", "java", "csharp", "php", "ruby", or "c"
     "real_time_sync": True,  # Enable real-time file sync during engineering

--- a/src/reverse_api/ollama_runtime.py
+++ b/src/reverse_api/ollama_runtime.py
@@ -1,0 +1,307 @@
+"""Ollama discovery, lifecycle, and OpenCode provider configuration."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from .utils import get_config_path
+
+DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+MIN_OPENCODE_CONTEXT = 65_536
+_START_TIMEOUT_SECONDS = 30.0
+
+_PROCESS: subprocess.Popen[bytes] | None = None
+_PROCESS_URL: str | None = None
+_PROCESS_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False
+
+
+class OllamaSetupError(RuntimeError):
+    """Raised when Ollama or the selected model is not ready for agent use."""
+
+
+@dataclass(frozen=True)
+class OllamaModel:
+    """Installed Ollama model metadata relevant to OpenCode."""
+
+    name: str
+    size: int
+    capabilities: tuple[str, ...]
+    context_length: int
+    parameter_size: str = ""
+
+    @property
+    def supports_tools(self) -> bool:
+        return "tools" in self.capabilities
+
+    @property
+    def supports_opencode(self) -> bool:
+        return self.supports_tools and self.context_length >= MIN_OPENCODE_CONTEXT
+
+
+@dataclass(frozen=True)
+class OllamaStatus:
+    """Ollama daemon state and installed models."""
+
+    base_url: str
+    models: tuple[OllamaModel, ...]
+    started: bool = False
+
+    @property
+    def compatible_models(self) -> tuple[OllamaModel, ...]:
+        return tuple(model for model in self.models if model.supports_opencode)
+
+
+@dataclass(frozen=True)
+class OllamaProviderSetup:
+    """Validated model plus the daemon state used to configure OpenCode."""
+
+    status: OllamaStatus
+    model: OllamaModel
+
+
+def _config_manager_snapshot() -> dict[str, Any]:
+    try:
+        from .config import ConfigManager
+
+        return ConfigManager(get_config_path()).config.copy()
+    except Exception:
+        return {}
+
+
+def ollama_base_url() -> str:
+    """Return the Ollama API URL, with an RAE-specific env override."""
+
+    env = os.environ.get("RAE_OLLAMA_BASE_URL", "").strip()
+    if env:
+        if "://" not in env:
+            env = f"http://{env}"
+        return env.rstrip("/")
+    configured = str(_config_manager_snapshot().get("ollama_base_url") or DEFAULT_OLLAMA_BASE_URL)
+    return configured.rstrip("/")
+
+
+def ollama_auto_start() -> bool:
+    """Return whether RAE may start an installed Ollama daemon."""
+
+    env = os.environ.get("RAE_OLLAMA_AUTO_START")
+    if env is not None:
+        return env.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(_config_manager_snapshot().get("ollama_auto_start", True))
+
+
+def _parse_models(payload: dict[str, Any]) -> tuple[OllamaModel, ...]:
+    models: list[OllamaModel] = []
+    for raw in payload.get("models", []):
+        name = str(raw.get("name") or raw.get("model") or "").strip()
+        if not name:
+            continue
+        details = raw.get("details") or {}
+        capabilities = tuple(str(value) for value in raw.get("capabilities") or ())
+        models.append(
+            OllamaModel(
+                name=name,
+                size=int(raw.get("size") or 0),
+                capabilities=capabilities,
+                context_length=int(details.get("context_length") or 0),
+                parameter_size=str(details.get("parameter_size") or ""),
+            )
+        )
+    return tuple(models)
+
+
+def _server_address(base_url: str) -> tuple[str, int]:
+    parsed = urlparse(base_url)
+    host = parsed.hostname
+    if parsed.scheme != "http" or not host or parsed.path not in {"", "/"}:
+        raise OllamaSetupError(f"Cannot auto-start Ollama for {base_url!r}; use a plain local http URL.")
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        raise OllamaSetupError(f"Refusing to auto-start Ollama on non-loopback host {host!r}.")
+    try:
+        port = parsed.port or 80
+    except ValueError as e:
+        raise OllamaSetupError(f"Invalid Ollama URL {base_url!r}: {e}") from e
+    return host, port
+
+
+def _start_managed_server(base_url: str) -> tuple[subprocess.Popen[bytes], bool]:
+    global _ATEXIT_REGISTERED, _PROCESS, _PROCESS_URL
+
+    with _PROCESS_LOCK:
+        if _PROCESS is not None and _PROCESS.poll() is None:
+            if _PROCESS_URL != base_url:
+                raise OllamaSetupError(f"RAE already manages Ollama at {_PROCESS_URL}; it cannot also start {base_url}.")
+            return _PROCESS, False
+
+        host, port = _server_address(base_url)
+        executable = shutil.which("ollama")
+        if executable is None:
+            raise OllamaSetupError("Ollama is not running and the `ollama` command is not installed. Install it from https://ollama.com/download.")
+
+        child_env = os.environ.copy()
+        child_env["OLLAMA_HOST"] = f"{host}:{port}"
+        try:
+            process = subprocess.Popen(
+                [executable, "serve"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=child_env,
+                start_new_session=True,
+            )
+        except OSError as e:
+            raise OllamaSetupError(f"Could not start `ollama serve`: {e}") from e
+
+        _PROCESS = process
+        _PROCESS_URL = base_url
+        if not _ATEXIT_REGISTERED:
+            atexit.register(stop_managed_ollama_server)
+            _ATEXIT_REGISTERED = True
+        return process, True
+
+
+async def ensure_ollama_models(*, timeout: float = _START_TIMEOUT_SECONDS) -> OllamaStatus:
+    """Reuse Ollama or start an installed daemon, then return model metadata."""
+
+    base_url = ollama_base_url()
+    async with httpx.AsyncClient(base_url=base_url, timeout=2.0) as client:
+        try:
+            response = await client.get("/api/tags")
+            response.raise_for_status()
+            return OllamaStatus(base_url=base_url, models=_parse_models(response.json()))
+        except httpx.HTTPStatusError as e:
+            raise OllamaSetupError(f"Ollama at {base_url} returned HTTP {e.response.status_code} for /api/tags.") from e
+        except httpx.RequestError as initial_error:
+            if not ollama_auto_start():
+                raise OllamaSetupError(
+                    f"Ollama is not responding at {base_url} and automatic startup is disabled. Run `ollama serve` first."
+                ) from initial_error
+
+        process, started = _start_managed_server(base_url)
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise OllamaSetupError(f"`ollama serve` exited with status {process.returncode} before becoming healthy.")
+            try:
+                response = await client.get("/api/tags")
+                response.raise_for_status()
+                return OllamaStatus(base_url=base_url, models=_parse_models(response.json()), started=started)
+            except httpx.HTTPStatusError as e:
+                if started:
+                    stop_managed_ollama_server()
+                raise OllamaSetupError(f"Ollama at {base_url} returned HTTP {e.response.status_code} for /api/tags.") from e
+            except httpx.RequestError as e:
+                last_error = e
+                import asyncio
+
+                await asyncio.sleep(0.25)
+
+    if started:
+        stop_managed_ollama_server()
+    raise OllamaSetupError(f"Timed out after {timeout:.0f}s waiting for Ollama at {base_url}.") from last_error
+
+
+async def prepare_ollama_model(model_name: str) -> OllamaProviderSetup:
+    """Validate that an installed model can drive the OpenCode agent loop."""
+
+    status = await ensure_ollama_models()
+    selected = next((model for model in status.models if model.name == model_name), None)
+    if selected is None:
+        available = ", ".join(model.name for model in status.models) or "none"
+        raise OllamaSetupError(
+            f"Ollama model {model_name!r} is not installed. Installed models: {available}. Pull it explicitly with `ollama pull {model_name}`."
+        )
+    if not selected.supports_tools:
+        raise OllamaSetupError(f"Ollama model {model_name!r} does not advertise tool calling, which RAE requires.")
+    if selected.context_length < MIN_OPENCODE_CONTEXT:
+        raise OllamaSetupError(f"Ollama model {model_name!r} has a {selected.context_length:,}-token context; OpenCode requires at least 65,536.")
+    return OllamaProviderSetup(status=status, model=selected)
+
+
+def opencode_ollama_env(setup: OllamaProviderSetup) -> dict[str, str]:
+    """Build inline OpenCode config without overwriting a user's config file."""
+
+    raw = os.environ.get("OPENCODE_CONFIG_CONTENT", "").strip()
+    try:
+        config = json.loads(raw) if raw else {}
+    except json.JSONDecodeError as e:
+        raise OllamaSetupError(f"OPENCODE_CONFIG_CONTENT is not valid JSON: {e}") from e
+    if not isinstance(config, dict):
+        raise OllamaSetupError("OPENCODE_CONFIG_CONTENT must contain a JSON object.")
+
+    providers = config.setdefault("provider", {})
+    if not isinstance(providers, dict):
+        raise OllamaSetupError("OPENCODE_CONFIG_CONTENT field 'provider' must be a JSON object.")
+    ollama = providers.setdefault("ollama", {})
+    if not isinstance(ollama, dict):
+        raise OllamaSetupError("OPENCODE_CONFIG_CONTENT field 'provider.ollama' must be a JSON object.")
+    ollama["npm"] = "@ai-sdk/openai-compatible"
+    ollama["name"] = "Ollama"
+    options = ollama.setdefault("options", {})
+    if not isinstance(options, dict):
+        raise OllamaSetupError("OPENCODE_CONFIG_CONTENT field 'provider.ollama.options' must be a JSON object.")
+    options["baseURL"] = f"{setup.status.base_url}/v1"
+    models = ollama.setdefault("models", {})
+    if not isinstance(models, dict):
+        raise OllamaSetupError("OPENCODE_CONFIG_CONTENT field 'provider.ollama.models' must be a JSON object.")
+    for model in setup.status.compatible_models:
+        models[model.name] = {
+            "name": model.name,
+            "limit": {
+                "context": model.context_length,
+                "output": min(model.context_length, 8192),
+            },
+        }
+    config["small_model"] = f"ollama/{setup.model.name}"
+    return {"OPENCODE_CONFIG_CONTENT": json.dumps(config, separators=(",", ":"), sort_keys=True)}
+
+
+async def validate_opencode_ollama_provider(client: httpx.AsyncClient, model_name: str) -> None:
+    """Ensure a reused OpenCode server already exposes the selected Ollama model."""
+
+    response = await client.get("/config", timeout=5.0)
+    response.raise_for_status()
+    config = response.json()
+    if not isinstance(config, dict):
+        raise OllamaSetupError("OpenCode returned an invalid configuration response.")
+    model_config = ((config.get("provider") or {}).get("ollama") or {}).get("models") or {}
+    if model_name not in model_config:
+        raise OllamaSetupError(
+            "The existing OpenCode server is not configured for "
+            f"ollama/{model_name}. Stop it so RAE can start a configured server, or restart it with `ollama launch opencode`."
+        )
+
+
+def stop_managed_ollama_server() -> None:
+    """Stop the Ollama child process started by RAE, if any."""
+
+    global _PROCESS, _PROCESS_URL
+
+    with _PROCESS_LOCK:
+        process = _PROCESS
+        _PROCESS = None
+        _PROCESS_URL = None
+
+    if process is None or process.poll() is not None:
+        return
+    try:
+        process.terminate()
+    except OSError:
+        return
+    try:
+        process.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=3)

--- a/src/reverse_api/ollama_runtime.py
+++ b/src/reverse_api/ollama_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import json
 import os
@@ -101,24 +102,57 @@ def ollama_auto_start() -> bool:
     return bool(_config_manager_snapshot().get("ollama_auto_start", True))
 
 
-def _parse_models(payload: dict[str, Any]) -> tuple[OllamaModel, ...]:
-    models: list[OllamaModel] = []
-    for raw in payload.get("models", []):
-        name = str(raw.get("name") or raw.get("model") or "").strip()
-        if not name:
+def _context_length(show: dict[str, Any]) -> int:
+    """Read the architecture-specific context window returned by /api/show."""
+
+    model_info = show.get("model_info") or {}
+    if not isinstance(model_info, dict):
+        return 0
+    architecture = str(model_info.get("general.architecture") or "").strip()
+    keys = [f"{architecture}.context_length"] if architecture else []
+    keys.extend(key for key in model_info if str(key).endswith(".context_length") and key not in keys)
+    for key in keys:
+        try:
+            return int(model_info[key])
+        except (KeyError, TypeError, ValueError):
             continue
-        details = raw.get("details") or {}
-        capabilities = tuple(str(value) for value in raw.get("capabilities") or ())
-        models.append(
-            OllamaModel(
-                name=name,
-                size=int(raw.get("size") or 0),
-                capabilities=capabilities,
-                context_length=int(details.get("context_length") or 0),
-                parameter_size=str(details.get("parameter_size") or ""),
-            )
-        )
-    return tuple(models)
+    return 0
+
+
+def _parse_model(tag: dict[str, Any], show: dict[str, Any]) -> OllamaModel:
+    """Merge list metadata from /api/tags with capabilities from /api/show."""
+
+    name = str(tag.get("name") or tag.get("model") or "").strip()
+    details = show.get("details") or {}
+    if not isinstance(details, dict):
+        details = {}
+    return OllamaModel(
+        name=name,
+        size=int(tag.get("size") or 0),
+        capabilities=tuple(str(value) for value in show.get("capabilities") or ()),
+        context_length=_context_length(show),
+        parameter_size=str(details.get("parameter_size") or ""),
+    )
+
+
+async def _load_models(client: httpx.AsyncClient, base_url: str, payload: dict[str, Any]) -> tuple[OllamaModel, ...]:
+    """Enrich every installed model with its authoritative /api/show metadata."""
+
+    tags = [raw for raw in payload.get("models", []) if isinstance(raw, dict) and str(raw.get("name") or raw.get("model") or "").strip()]
+
+    async def load(tag: dict[str, Any]) -> OllamaModel:
+        name = str(tag.get("name") or tag.get("model")).strip()
+        response = await client.post("/api/show", json={"model": name})
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise OllamaSetupError(f"Ollama at {base_url} returned HTTP {e.response.status_code} for /api/show ({name}).") from e
+        show = response.json()
+        if not isinstance(show, dict):
+            raise OllamaSetupError(f"Ollama returned invalid /api/show metadata for {name!r}.")
+        return _parse_model(tag, show)
+
+    return tuple(await asyncio.gather(*(load(tag) for tag in tags)))
 
 
 def _server_address(base_url: str) -> tuple[str, int]:
@@ -179,7 +213,7 @@ async def ensure_ollama_models(*, timeout: float = _START_TIMEOUT_SECONDS) -> Ol
         try:
             response = await client.get("/api/tags")
             response.raise_for_status()
-            return OllamaStatus(base_url=base_url, models=_parse_models(response.json()))
+            return OllamaStatus(base_url=base_url, models=await _load_models(client, base_url, response.json()))
         except httpx.HTTPStatusError as e:
             raise OllamaSetupError(f"Ollama at {base_url} returned HTTP {e.response.status_code} for /api/tags.") from e
         except httpx.RequestError as initial_error:
@@ -197,15 +231,17 @@ async def ensure_ollama_models(*, timeout: float = _START_TIMEOUT_SECONDS) -> Ol
             try:
                 response = await client.get("/api/tags")
                 response.raise_for_status()
-                return OllamaStatus(base_url=base_url, models=_parse_models(response.json()), started=started)
+                return OllamaStatus(
+                    base_url=base_url,
+                    models=await _load_models(client, base_url, response.json()),
+                    started=started,
+                )
             except httpx.HTTPStatusError as e:
                 if started:
                     stop_managed_ollama_server()
                 raise OllamaSetupError(f"Ollama at {base_url} returned HTTP {e.response.status_code} for /api/tags.") from e
             except httpx.RequestError as e:
                 last_error = e
-                import asyncio
-
                 await asyncio.sleep(0.25)
 
     if started:

--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -15,6 +15,13 @@ import httpx
 
 from .base_engineer import BaseEngineer
 from .config import DEFAULT_OPENCODE_MODEL, DEFAULT_OPENCODE_PROVIDER
+from .ollama_runtime import (
+    OllamaProviderSetup,
+    OllamaSetupError,
+    opencode_ollama_env,
+    prepare_ollama_model,
+    validate_opencode_ollama_provider,
+)
 from .opencode_runtime import (
     OpenCodeSetupError,
     ensure_opencode_server,
@@ -146,7 +153,16 @@ class OpenCodeEngineer(BaseEngineer):
     async def _prepare_server(self, client: httpx.AsyncClient) -> bool:
         """Ensure OpenCode is healthy, starting the managed runtime if needed."""
         try:
-            server = await ensure_opencode_server(client, base_url=self.BASE_URL)
+            ollama_setup: OllamaProviderSetup | None = None
+            env_overrides: dict[str, str] = {}
+            if self.opencode_provider == "ollama":
+                ollama_setup = await prepare_ollama_model(self.opencode_model)
+                env_overrides = opencode_ollama_env(ollama_setup)
+
+            server = await ensure_opencode_server(client, base_url=self.BASE_URL, env_overrides=env_overrides)
+            if ollama_setup is not None:
+                await validate_opencode_ollama_provider(client, self.opencode_model)
+                self.opencode_ui.ollama_ready(self.opencode_model, ollama_setup.status.started)
             if server.started and server.package:
                 self.opencode_ui.server_started(server.package, self.BASE_URL)
             self.opencode_ui.health_check(server.health)
@@ -164,7 +180,7 @@ class OpenCodeEngineer(BaseEngineer):
             if self.opencode_username != "opencode":
                 self.opencode_ui.console.print(f"[dim]Username: {self.opencode_username}[/dim]")
             return False
-        except OpenCodeSetupError as e:
+        except (OllamaSetupError, OpenCodeSetupError) as e:
             debug_log(f"OpenCode setup failed: {e}")
             self.opencode_ui.error(str(e), unexpected=False)
             return False

--- a/src/reverse_api/opencode_runtime.py
+++ b/src/reverse_api/opencode_runtime.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -29,6 +30,7 @@ _START_TIMEOUT_SECONDS = 120.0
 
 _PROCESS: subprocess.Popen[bytes] | None = None
 _PROCESS_URL: str | None = None
+_PROCESS_ENV_OVERRIDES: dict[str, str] = {}
 _PROCESS_LOCK = threading.Lock()
 _ATEXIT_REGISTERED = False
 
@@ -246,15 +248,22 @@ def _server_address(base_url: str) -> tuple[str, int]:
     return host, port
 
 
-def _start_managed_server(base_url: str) -> tuple[subprocess.Popen[bytes], str, bool]:
+def _start_managed_server(
+    base_url: str,
+    env_overrides: Mapping[str, str] | None = None,
+) -> tuple[subprocess.Popen[bytes], str, bool]:
     """Start the configured OpenCode npm package once for this process."""
 
-    global _ATEXIT_REGISTERED, _PROCESS, _PROCESS_URL
+    global _ATEXIT_REGISTERED, _PROCESS, _PROCESS_ENV_OVERRIDES, _PROCESS_URL
+
+    desired_env = dict(env_overrides or {})
 
     with _PROCESS_LOCK:
         if _PROCESS is not None and _PROCESS.poll() is None:
             if _PROCESS_URL != base_url:
                 raise OpenCodeSetupError(f"RAE already manages OpenCode at {_PROCESS_URL}; it cannot also start {base_url} in the same process.")
+            if _PROCESS_ENV_OVERRIDES != desired_env:
+                raise OpenCodeSetupError("The managed OpenCode server needs different provider configuration; restart it and retry.")
             return _PROCESS, opencode_npx_package(), False
 
         host, port = _server_address(base_url)
@@ -266,13 +275,15 @@ def _start_managed_server(base_url: str) -> tuple[subprocess.Popen[bytes], str, 
 
         package = opencode_npx_package()
         argv = [npx, "-y", package, "serve", "--hostname", host, "--port", str(port)]
+        child_env = os.environ.copy()
+        child_env.update(desired_env)
         try:
             process = subprocess.Popen(
                 argv,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                env=os.environ.copy(),
+                env=child_env,
                 start_new_session=True,
             )
         except OSError as e:
@@ -280,6 +291,7 @@ def _start_managed_server(base_url: str) -> tuple[subprocess.Popen[bytes], str, 
 
         _PROCESS = process
         _PROCESS_URL = base_url
+        _PROCESS_ENV_OVERRIDES = desired_env
         if not _ATEXIT_REGISTERED:
             atexit.register(stop_managed_opencode_server)
             _ATEXIT_REGISTERED = True
@@ -290,6 +302,7 @@ async def ensure_opencode_server(
     client: httpx.AsyncClient,
     *,
     base_url: str,
+    env_overrides: Mapping[str, str] | None = None,
     timeout: float = _START_TIMEOUT_SECONDS,
 ) -> OpenCodeServerStatus:
     """Reuse a healthy server or start the configured OpenCode release locally."""
@@ -301,7 +314,12 @@ async def ensure_opencode_server(
         if not isinstance(health, dict):
             raise OpenCodeSetupError("OpenCode returned an invalid health response.")
         version_warning = opencode_version_warning(health)
-        return OpenCodeServerStatus(health=health, version_warning=version_warning)
+        desired_env = dict(env_overrides or {})
+        with _PROCESS_LOCK:
+            restart_managed = _PROCESS is not None and _PROCESS.poll() is None and _PROCESS_URL == base_url and _PROCESS_ENV_OVERRIDES != desired_env
+        if not restart_managed:
+            return OpenCodeServerStatus(health=health, version_warning=version_warning)
+        stop_managed_opencode_server()
     except httpx.HTTPStatusError:
         raise
     except httpx.RequestError as initial_error:
@@ -310,7 +328,7 @@ async def ensure_opencode_server(
                 f"OpenCode is not responding at {base_url} and automatic startup is disabled. Run `opencode serve` first."
             ) from initial_error
 
-    process, package, started = _start_managed_server(base_url)
+    process, package, started = _start_managed_server(base_url, env_overrides)
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
     while time.monotonic() < deadline:
@@ -352,12 +370,13 @@ async def ensure_opencode_server(
 def stop_managed_opencode_server() -> None:
     """Stop the OpenCode child process started by RAE, if any."""
 
-    global _PROCESS, _PROCESS_URL
+    global _PROCESS, _PROCESS_ENV_OVERRIDES, _PROCESS_URL
 
     with _PROCESS_LOCK:
         process = _PROCESS
         _PROCESS = None
         _PROCESS_URL = None
+        _PROCESS_ENV_OVERRIDES = {}
 
     if process is None or process.poll() is not None:
         return

--- a/src/reverse_api/opencode_ui.py
+++ b/src/reverse_api/opencode_ui.py
@@ -53,6 +53,11 @@ class OpenCodeUI:
         """Display a concise warning for an older or unknown server version."""
         self.console.print(f"  [yellow]warning:[/yellow] {message}")
 
+    def ollama_ready(self, model: str, started: bool = False) -> None:
+        """Display the validated Ollama model and daemon state."""
+        action = "started" if started else "connected"
+        self.console.print(f"  [dim]ollama: {action}, using {model}[/dim]")
+
     def session_created(self, session_id: str) -> None:
         """Display session creation."""
         self.console.print(f"  [dim]session: {session_id[:16]}...[/dim]")

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -153,6 +153,7 @@ async def _generate_folder_name_opencode_async(prompt: str, session_id: str = No
     import json
 
     from .config import DEFAULT_OPENCODE_MODEL, DEFAULT_OPENCODE_PROVIDER, ConfigManager
+    from .ollama_runtime import opencode_ollama_env, prepare_ollama_model, validate_opencode_ollama_provider
     from .opencode_runtime import ensure_opencode_server, opencode_base_url, validate_opencode_model
 
     base_url = opencode_base_url()
@@ -172,7 +173,13 @@ async def _generate_folder_name_opencode_async(prompt: str, session_id: str = No
 
     async with httpx.AsyncClient(base_url=base_url, timeout=15.0, auth=auth) as client:
         try:
-            await ensure_opencode_server(client, base_url=base_url)
+            env_overrides: dict[str, str] = {}
+            if opencode_provider == "ollama":
+                ollama_setup = await prepare_ollama_model(opencode_model)
+                env_overrides = opencode_ollama_env(ollama_setup)
+            await ensure_opencode_server(client, base_url=base_url, env_overrides=env_overrides)
+            if opencode_provider == "ollama":
+                await validate_opencode_ollama_provider(client, opencode_model)
             await validate_opencode_model(client, opencode_provider, opencode_model)
         except Exception as e:
             raise Exception(f"OpenCode server not responding: {e}") from e

--- a/tests/test_cli_ollama.py
+++ b/tests/test_cli_ollama.py
@@ -1,0 +1,67 @@
+"""Tests for Ollama model selection in CLI settings."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from reverse_api import cli
+from reverse_api.ollama_runtime import OllamaModel, OllamaStatus
+
+
+def _model(name: str, *, size: int = 100) -> OllamaModel:
+    return OllamaModel(
+        name=name,
+        size=size,
+        capabilities=("completion", "tools"),
+        context_length=131_072,
+        parameter_size="20B",
+    )
+
+
+def test_single_compatible_model_is_selected_without_prompt():
+    status = OllamaStatus(base_url="http://127.0.0.1:11434", models=(_model("only:model"),))
+
+    with patch("reverse_api.ollama_runtime.ensure_ollama_models", new=AsyncMock(return_value=status)):
+        with patch.object(cli.questionary, "select") as select:
+            selected = cli._select_ollama_model_for_settings()
+
+    assert selected == "only:model"
+    select.assert_not_called()
+
+
+def test_multiple_compatible_models_show_picker():
+    status = OllamaStatus(
+        base_url="http://127.0.0.1:11434",
+        models=(_model("local:model", size=2_000_000_000), _model("cloud:model")),
+    )
+    prompt = MagicMock()
+    prompt.ask.return_value = "cloud:model"
+
+    with patch("reverse_api.ollama_runtime.ensure_ollama_models", new=AsyncMock(return_value=status)):
+        with patch.object(cli.questionary, "select", return_value=prompt) as select:
+            selected = cli._select_ollama_model_for_settings()
+
+    assert selected == "cloud:model"
+    choices = select.call_args.kwargs["choices"]
+    assert "1.9 GB" in choices[0].title
+    assert "cloud" in choices[1].title
+
+
+def test_live_opencode_picker_always_offers_ollama():
+    """Ollama can bootstrap itself even when it is absent from OpenCode's current catalog."""
+    catalog = {"default": {}, "providers": []}
+    provider_prompt = MagicMock()
+    provider_prompt.ask.return_value = "ollama"
+
+    with patch.object(
+        cli,
+        "_load_opencode_catalog_for_settings",
+        new=AsyncMock(return_value=catalog),
+    ):
+        with patch.object(cli.questionary, "select", return_value=provider_prompt) as select:
+            with patch.object(cli, "_select_ollama_model_for_settings", return_value="qwen3:8b"):
+                selected = cli._select_opencode_pair_for_settings()
+
+    assert selected == ("ollama", "qwen3:8b")
+    choices = select.call_args.kwargs["choices"]
+    assert [choice.value for choice in choices] == ["ollama", "back"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,6 +156,8 @@ class TestDefaultConfig:
             "opencode_auto_start",
             "opencode_base_url",
             "opencode_npx_package",
+            "ollama_auto_start",
+            "ollama_base_url",
             "output_dir",
             "output_language",
             "real_time_sync",
@@ -176,3 +178,5 @@ class TestDefaultConfig:
         assert DEFAULT_CONFIG["opencode_model"] == "big-pickle"
         assert DEFAULT_CONFIG["opencode_auto_start"] is True
         assert DEFAULT_CONFIG["opencode_npx_package"] == "opencode-ai@latest"
+        assert DEFAULT_CONFIG["ollama_auto_start"] is True
+        assert DEFAULT_CONFIG["ollama_base_url"] == "http://127.0.0.1:11434"

--- a/tests/test_ollama_runtime.py
+++ b/tests/test_ollama_runtime.py
@@ -1,0 +1,163 @@
+"""Tests for Ollama discovery and OpenCode configuration."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from reverse_api import ollama_runtime
+
+
+def _payload() -> dict:
+    return {
+        "models": [
+            {
+                "name": "qwen3:4b",
+                "size": 2_497_000_000,
+                "capabilities": ["completion", "tools", "thinking"],
+                "details": {"parameter_size": "4.0B", "context_length": 262_144},
+            },
+            {
+                "name": "tiny:no-tools",
+                "size": 100,
+                "capabilities": ["completion"],
+                "details": {"parameter_size": "1B", "context_length": 131_072},
+            },
+            {
+                "name": "tools:short-context",
+                "size": 200,
+                "capabilities": ["completion", "tools"],
+                "details": {"parameter_size": "2B", "context_length": 32_768},
+            },
+        ]
+    }
+
+
+def _response(payload: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = payload or _payload()
+    return response
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_state():
+    ollama_runtime._PROCESS = None
+    ollama_runtime._PROCESS_URL = None
+    yield
+    ollama_runtime._PROCESS = None
+    ollama_runtime._PROCESS_URL = None
+
+
+def test_parse_models_filters_agent_compatible_models():
+    models = ollama_runtime._parse_models(_payload())
+    status = ollama_runtime.OllamaStatus(base_url="http://127.0.0.1:11434", models=models)
+
+    assert [model.name for model in models] == ["qwen3:4b", "tiny:no-tools", "tools:short-context"]
+    assert [model.name for model in status.compatible_models] == ["qwen3:4b"]
+
+
+@pytest.mark.asyncio
+async def test_reuses_running_ollama():
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_response())
+
+    with patch.object(ollama_runtime.httpx, "AsyncClient") as async_client:
+        async_client.return_value.__aenter__ = AsyncMock(return_value=client)
+        async_client.return_value.__aexit__ = AsyncMock(return_value=False)
+        status = await ollama_runtime.ensure_ollama_models()
+
+    assert status.started is False
+    assert status.models[0].name == "qwen3:4b"
+
+
+@pytest.mark.asyncio
+async def test_starts_installed_ollama_daemon(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RAE_OLLAMA_BASE_URL", "127.0.0.1:11434")
+    request = httpx.Request("GET", "http://127.0.0.1:11434/api/tags")
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=[httpx.ConnectError("refused", request=request), _response()])
+    process = MagicMock()
+    process.poll.return_value = None
+
+    with patch.object(ollama_runtime.httpx, "AsyncClient") as async_client:
+        async_client.return_value.__aenter__ = AsyncMock(return_value=client)
+        async_client.return_value.__aexit__ = AsyncMock(return_value=False)
+        with patch.object(ollama_runtime.shutil, "which", return_value="/usr/local/bin/ollama"):
+            with patch.object(ollama_runtime.subprocess, "Popen", return_value=process) as popen:
+                status = await ollama_runtime.ensure_ollama_models(timeout=1)
+
+    assert status.started is True
+    assert popen.call_args.args[0] == ["/usr/local/bin/ollama", "serve"]
+    assert popen.call_args.kwargs["env"]["OLLAMA_HOST"] == "127.0.0.1:11434"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_name", "message"),
+    [
+        ("missing:model", "not installed"),
+        ("tiny:no-tools", "does not advertise tool calling"),
+        ("tools:short-context", "requires at least 65,536"),
+    ],
+)
+async def test_prepare_model_rejects_incompatible_models(model_name: str, message: str):
+    status = ollama_runtime.OllamaStatus(
+        base_url="http://127.0.0.1:11434",
+        models=ollama_runtime._parse_models(_payload()),
+    )
+    with patch.object(ollama_runtime, "ensure_ollama_models", new=AsyncMock(return_value=status)):
+        with pytest.raises(ollama_runtime.OllamaSetupError, match=message):
+            await ollama_runtime.prepare_ollama_model(model_name)
+
+
+def test_opencode_env_preserves_existing_config(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", '{"plugin":["example"],"provider":{"custom":{"name":"Custom"}}}')
+    status = ollama_runtime.OllamaStatus(
+        base_url="http://127.0.0.1:11434",
+        models=ollama_runtime._parse_models(_payload()),
+    )
+    setup = ollama_runtime.OllamaProviderSetup(status=status, model=status.models[0])
+
+    env = ollama_runtime.opencode_ollama_env(setup)
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+
+    assert config["plugin"] == ["example"]
+    assert config["provider"]["custom"]["name"] == "Custom"
+    assert config["provider"]["ollama"]["options"]["baseURL"] == "http://127.0.0.1:11434/v1"
+    assert list(config["provider"]["ollama"]["models"]) == ["qwen3:4b"]
+    assert config["small_model"] == "ollama/qwen3:4b"
+
+
+@pytest.mark.asyncio
+async def test_validate_existing_opencode_ollama_config():
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_response({"provider": {"ollama": {"models": {"qwen3:4b": {"name": "qwen3:4b"}}}}}))
+
+    await ollama_runtime.validate_opencode_ollama_provider(client, "qwen3:4b")
+
+    client.get.assert_awaited_once_with("/config", timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_validate_existing_opencode_requires_model_config():
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_response({"provider": {}}))
+
+    with pytest.raises(ollama_runtime.OllamaSetupError, match="not configured"):
+        await ollama_runtime.validate_opencode_ollama_provider(client, "qwen3:4b")
+
+
+def test_stop_managed_ollama_server():
+    process = MagicMock()
+    process.poll.return_value = None
+    ollama_runtime._PROCESS = process
+    ollama_runtime._PROCESS_URL = "http://127.0.0.1:11434"
+
+    ollama_runtime.stop_managed_ollama_server()
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once_with(timeout=3)

--- a/tests/test_ollama_runtime.py
+++ b/tests/test_ollama_runtime.py
@@ -11,35 +11,50 @@ import pytest
 from reverse_api import ollama_runtime
 
 
-def _payload() -> dict:
+def _tags_payload() -> dict:
     return {
         "models": [
             {
                 "name": "qwen3:4b",
                 "size": 2_497_000_000,
-                "capabilities": ["completion", "tools", "thinking"],
-                "details": {"parameter_size": "4.0B", "context_length": 262_144},
             },
             {
                 "name": "tiny:no-tools",
                 "size": 100,
-                "capabilities": ["completion"],
-                "details": {"parameter_size": "1B", "context_length": 131_072},
             },
             {
                 "name": "tools:short-context",
                 "size": 200,
-                "capabilities": ["completion", "tools"],
-                "details": {"parameter_size": "2B", "context_length": 32_768},
             },
         ]
     }
 
 
+def _show_payload(model: str) -> dict:
+    metadata = {
+        "qwen3:4b": ("qwen3", ["completion", "tools", "thinking"], "4.0B", 262_144),
+        "tiny:no-tools": ("llama", ["completion"], "1B", 131_072),
+        "tools:short-context": ("qwen", ["completion", "tools"], "2B", 32_768),
+    }
+    architecture, capabilities, parameter_size, context_length = metadata[model]
+    return {
+        "capabilities": capabilities,
+        "details": {"parameter_size": parameter_size},
+        "model_info": {
+            "general.architecture": architecture,
+            f"{architecture}.context_length": context_length,
+        },
+    }
+
+
+def _models() -> tuple[ollama_runtime.OllamaModel, ...]:
+    return tuple(ollama_runtime._parse_model(tag, _show_payload(tag["name"])) for tag in _tags_payload()["models"])
+
+
 def _response(payload: dict | None = None) -> MagicMock:
     response = MagicMock()
     response.raise_for_status = MagicMock()
-    response.json.return_value = payload or _payload()
+    response.json.return_value = payload if payload is not None else _tags_payload()
     return response
 
 
@@ -52,8 +67,8 @@ def reset_runtime_state():
     ollama_runtime._PROCESS_URL = None
 
 
-def test_parse_models_filters_agent_compatible_models():
-    models = ollama_runtime._parse_models(_payload())
+def test_parse_show_metadata_filters_agent_compatible_models():
+    models = _models()
     status = ollama_runtime.OllamaStatus(base_url="http://127.0.0.1:11434", models=models)
 
     assert [model.name for model in models] == ["qwen3:4b", "tiny:no-tools", "tools:short-context"]
@@ -64,6 +79,7 @@ def test_parse_models_filters_agent_compatible_models():
 async def test_reuses_running_ollama():
     client = AsyncMock()
     client.get = AsyncMock(return_value=_response())
+    client.post = AsyncMock(side_effect=lambda _path, json: _response(_show_payload(json["model"])))
 
     with patch.object(ollama_runtime.httpx, "AsyncClient") as async_client:
         async_client.return_value.__aenter__ = AsyncMock(return_value=client)
@@ -72,6 +88,9 @@ async def test_reuses_running_ollama():
 
     assert status.started is False
     assert status.models[0].name == "qwen3:4b"
+    assert status.models[0].supports_opencode is True
+    assert client.post.await_count == 3
+    client.post.assert_any_await("/api/show", json={"model": "qwen3:4b"})
 
 
 @pytest.mark.asyncio
@@ -80,6 +99,7 @@ async def test_starts_installed_ollama_daemon(monkeypatch: pytest.MonkeyPatch):
     request = httpx.Request("GET", "http://127.0.0.1:11434/api/tags")
     client = AsyncMock()
     client.get = AsyncMock(side_effect=[httpx.ConnectError("refused", request=request), _response()])
+    client.post = AsyncMock(side_effect=lambda _path, json: _response(_show_payload(json["model"])))
     process = MagicMock()
     process.poll.return_value = None
 
@@ -107,7 +127,7 @@ async def test_starts_installed_ollama_daemon(monkeypatch: pytest.MonkeyPatch):
 async def test_prepare_model_rejects_incompatible_models(model_name: str, message: str):
     status = ollama_runtime.OllamaStatus(
         base_url="http://127.0.0.1:11434",
-        models=ollama_runtime._parse_models(_payload()),
+        models=_models(),
     )
     with patch.object(ollama_runtime, "ensure_ollama_models", new=AsyncMock(return_value=status)):
         with pytest.raises(ollama_runtime.OllamaSetupError, match=message):
@@ -118,7 +138,7 @@ def test_opencode_env_preserves_existing_config(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", '{"plugin":["example"],"provider":{"custom":{"name":"Custom"}}}')
     status = ollama_runtime.OllamaStatus(
         base_url="http://127.0.0.1:11434",
-        models=ollama_runtime._parse_models(_payload()),
+        models=_models(),
     )
     setup = ollama_runtime.OllamaProviderSetup(status=status, model=status.models[0])
 

--- a/tests/test_opencode_engineer.py
+++ b/tests/test_opencode_engineer.py
@@ -1249,6 +1249,48 @@ class TestOpenCodeEngineerAnalyzeAndGenerate:
                     return eng
 
     @pytest.mark.asyncio
+    async def test_prepare_server_configures_ollama_before_opencode(self, tmp_path):
+        eng = self._make_engineer(tmp_path)
+        eng.opencode_provider = "ollama"
+        eng.opencode_model = "qwen3:4b"
+        client = AsyncMock()
+        ollama_setup = MagicMock()
+        ollama_setup.status.started = False
+        server = MagicMock(started=True, package="opencode-ai@latest", health={"version": "1.18.4"})
+
+        with patch(
+            "reverse_api.opencode_engineer.prepare_ollama_model",
+            new=AsyncMock(return_value=ollama_setup),
+        ) as prepare:
+            with patch(
+                "reverse_api.opencode_engineer.opencode_ollama_env",
+                return_value={"OPENCODE_CONFIG_CONTENT": "{}"},
+            ):
+                with patch(
+                    "reverse_api.opencode_engineer.ensure_opencode_server",
+                    new=AsyncMock(return_value=server),
+                ) as ensure:
+                    with patch(
+                        "reverse_api.opencode_engineer.validate_opencode_ollama_provider",
+                        new=AsyncMock(),
+                    ) as validate:
+                        with patch(
+                            "reverse_api.opencode_engineer.validate_opencode_model",
+                            new=AsyncMock(),
+                        ) as validate_model:
+                            assert await eng._prepare_server(client) is True
+
+        prepare.assert_awaited_once_with("qwen3:4b")
+        ensure.assert_awaited_once_with(
+            client,
+            base_url=eng.BASE_URL,
+            env_overrides={"OPENCODE_CONFIG_CONTENT": "{}"},
+        )
+        validate.assert_awaited_once_with(client, "qwen3:4b")
+        validate_model.assert_awaited_once_with(client, "ollama", "qwen3:4b")
+        eng.opencode_ui.ollama_ready.assert_called_once_with("qwen3:4b", False)
+
+    @pytest.mark.asyncio
     async def test_health_check_401(self, tmp_path):
         """401 on health check returns None."""
         eng = self._make_engineer(tmp_path)

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -14,9 +14,11 @@ from reverse_api import opencode_runtime
 def reset_runtime_state():
     opencode_runtime._PROCESS = None
     opencode_runtime._PROCESS_URL = None
+    opencode_runtime._PROCESS_ENV_OVERRIDES = {}
     yield
     opencode_runtime._PROCESS = None
     opencode_runtime._PROCESS_URL = None
+    opencode_runtime._PROCESS_ENV_OVERRIDES = {}
 
 
 def _health_response(version: str = "1.18.4") -> MagicMock:
@@ -162,6 +164,7 @@ async def test_starts_latest_package_without_global_opencode(monkeypatch: pytest
                 status = await opencode_runtime.ensure_opencode_server(
                     client,
                     base_url="http://127.0.0.1:4096",
+                    env_overrides={"OPENCODE_CONFIG_CONTENT": "{}"},
                     timeout=1,
                 )
 
@@ -180,6 +183,7 @@ async def test_starts_latest_package_without_global_opencode(monkeypatch: pytest
         "4096",
     ]
     assert popen.call_args.kwargs["env"]["OPENCODE_SERVER_PASSWORD"] == "secret"
+    assert popen.call_args.kwargs["env"]["OPENCODE_CONFIG_CONTENT"] == "{}"
 
 
 @pytest.mark.asyncio
@@ -191,6 +195,33 @@ async def test_disabled_auto_start_has_actionable_error(monkeypatch: pytest.Monk
 
     with pytest.raises(opencode_runtime.OpenCodeSetupError, match="disabled"):
         await opencode_runtime.ensure_opencode_server(client, base_url="http://127.0.0.1:4096")
+
+
+@pytest.mark.asyncio
+async def test_restarts_managed_server_when_provider_config_changes():
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=[_health_response(), _health_response()])
+    old_process = MagicMock()
+    old_process.poll.return_value = None
+    new_process = MagicMock()
+    new_process.poll.return_value = None
+    opencode_runtime._PROCESS = old_process
+    opencode_runtime._PROCESS_URL = "http://127.0.0.1:4096"
+    opencode_runtime._PROCESS_ENV_OVERRIDES = {"OPENCODE_CONFIG_CONTENT": '{"old":true}'}
+
+    with patch.object(opencode_runtime, "_config_manager_snapshot", return_value={}):
+        with patch.object(opencode_runtime.shutil, "which", side_effect=lambda name: f"/bin/{name}"):
+            with patch.object(opencode_runtime.subprocess, "Popen", return_value=new_process):
+                status = await opencode_runtime.ensure_opencode_server(
+                    client,
+                    base_url="http://127.0.0.1:4096",
+                    env_overrides={"OPENCODE_CONFIG_CONTENT": '{"ollama":true}'},
+                    timeout=1,
+                )
+
+    assert status.started is True
+    old_process.terminate.assert_called_once_with()
+    assert opencode_runtime._PROCESS_ENV_OVERRIDES == {"OPENCODE_CONFIG_CONTENT": '{"ollama":true}'}
 
 
 @pytest.mark.asyncio

--- a/tests/test_opencode_ui.py
+++ b/tests/test_opencode_ui.py
@@ -72,6 +72,14 @@ class TestOpenCodeUI:
         assert "warning:" in output
         assert "older than the tested version" in output
 
+    def test_ollama_ready(self):
+        """Ollama status shows whether RAE started or reused the daemon."""
+        ui, console = self._make_ui()
+        ui.ollama_ready("qwen3:4b", started=True)
+        output = console.file.getvalue()
+        assert "started" in output
+        assert "qwen3:4b" in output
+
     def test_session_created(self):
         """Session created shows truncated ID."""
         ui, console = self._make_ui()

--- a/website/content/docs/configuration/models.mdx
+++ b/website/content/docs/configuration/models.mdx
@@ -65,6 +65,10 @@ from your OpenCode server, marks free OpenCode options, and saves the pair
 together. Advanced users can still edit the `opencode_model` and
 `opencode_provider` keys directly.
 
+For Ollama, set `opencode_provider` to `ollama`. The `/settings` flow discovers
+installed models and only offers those that report tool calling plus the 64k
+context OpenCode requires. RAE does not pull models automatically.
+
 ## Copilot and Cursor users
 
 Copilot uses `copilot_model` (default `gpt-5`). Cursor uses `cursor_model`

--- a/website/content/docs/configuration/sdks.mdx
+++ b/website/content/docs/configuration/sdks.mdx
@@ -57,6 +57,36 @@ include valid alternatives plus currently exposed free, tool-capable models.
 Existing compatible servers are reused; versions older than RAE's tested
 OpenCode release display an upgrade warning.
 
+### Ollama through OpenCode
+
+In `/settings`, set the OpenCode provider to `ollama`. RAE connects to the
+configured Ollama daemon (default `http://127.0.0.1:11434`) and offers the
+installed models that advertise tool calling and at least 64k context. Picking
+one updates both `opencode_provider` and `opencode_model`.
+
+```json
+{
+  "sdk": "opencode",
+  "opencode_provider": "ollama",
+  "opencode_model": "qwen3.5",
+  "ollama_auto_start": true,
+  "ollama_base_url": "http://127.0.0.1:11434"
+}
+```
+
+RAE reuses a running Ollama daemon or starts `ollama serve` when the CLI is
+installed. It passes an inline provider definition to an auto-started OpenCode
+server, so it does not overwrite `opencode.json`. If you run OpenCode yourself,
+that existing server must already expose the selected Ollama model; RAE reports
+the exact remediation when it does not.
+
+Model downloads are intentionally explicit because they can consume many
+gigabytes: run `ollama pull <model>` yourself, then select it. Override daemon
+discovery with `RAE_OLLAMA_BASE_URL` and disable startup with
+`RAE_OLLAMA_AUTO_START=0`. See Ollama's
+[OpenCode integration](https://docs.ollama.com/integrations/opencode) for the
+upstream context-window guidance.
+
 ## Copilot
 
 Uses the GitHub Copilot SDK when the optional Copilot dependency and token are


### PR DESCRIPTION
Stacked on #107. Review that PR first; this PR contains only the Ollama layer.

## What

- discover installed Ollama models and only offer models that advertise tool calling with at least 64k context
- reuse an existing Ollama daemon, or start an installed `ollama serve` process when needed
- pass an inline Ollama provider definition to RAE-managed OpenCode without modifying `opencode.json`
- validate that an existing OpenCode server already exposes the selected Ollama model and provide a concrete restart instruction when it does not
- add an Ollama model picker to `/settings`, runtime status, configuration options, documentation, and tests

## Why

OpenCode can talk to Ollama, but RAE previously assumed the provider and both servers had already been configured manually. That made the local-model setup too fragile and slow for the normal RAE flow.

## Impact

- model downloads remain explicit; RAE never silently pulls multi-GB models
- existing user-managed servers remain preferred and are never stopped by RAE
- only processes started by RAE are cleaned up on exit
- `RAE_OLLAMA_BASE_URL` and `RAE_OLLAMA_AUTO_START=0` override the defaults

## Root cause

The OpenCode integration had no Ollama discovery, lifecycle management, or provider bootstrap path, so choosing an Ollama model alone was insufficient to make the OpenCode server recognize it.

## Checks

- `751 passed` with `tests/test_sync.py` excluded because of the existing macOS watchdog teardown crash
- `295 passed` across the affected runtime, CLI, engineer, UI, utility, and config tests
- Ruff passes for the new Ollama files and modified OpenCode runtime
- live local smoke test: real Ollama discovery, compatible model validation, managed `opencode-ai@latest` startup (v1.18.4), effective provider config validation, session creation, and clean shutdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Ollama support in OpenCode mode. RAE discovers compatible local models via `/api/show`, reuses or starts the Ollama daemon, and injects an inline `ollama` provider into OpenCode without modifying user config.

- **New Features**
  - Model discovery: lists installed Ollama models that support tools and ≥64k context; shows parameter size, binary size, and context; no silent downloads.
  - Daemon lifecycle: reuses a running daemon or starts `ollama serve` on localhost; respects `ollama_auto_start`, `ollama_base_url`, `RAE_OLLAMA_BASE_URL`, and `RAE_OLLAMA_AUTO_START=0`.
  - Provider bootstrap: supplies OpenCode’s `ollama` provider via OPENCODE_CONFIG_CONTENT to auto-started `opencode-ai@latest`; preserves `opencode.json`; restarts managed OpenCode when provider config changes.
  - CLI and UI: `/settings` always offers `ollama`; the model picker auto-selects when only one and shows GB/cloud size; UI shows “connected/started” with the selected model.
  - Config defaults: adds `ollama_auto_start` and `ollama_base_url`.

- **Bug Fixes**
  - Model compatibility: fetches per-model capabilities and architecture-specific context from `/api/show` instead of `/api/tags`, fixing rejection of valid installed models.

<sup>Written for commit f36fbed6c698c7a9fc173ef44f9781976781b498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Ollama support to the OpenCode workflow. The main changes are:

- Discovers installed, tool-capable Ollama models with sufficient context.
- Reuses or starts the local Ollama daemon.
- Injects Ollama provider settings into managed OpenCode servers.
- Adds model selection, runtime status, configuration, documentation, and tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Model capabilities and context length now come from each model's `/api/show` response.
- The updated tests cover discovery and compatibility filtering.
- No blocking issue remains in the reviewed fix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/reverse_api/ollama_runtime.py | Adds Ollama model discovery, metadata enrichment, daemon lifecycle management, compatibility checks, and OpenCode provider configuration. |
| src/reverse_api/opencode_runtime.py | Adds environment-aware startup and restart handling for managed OpenCode servers. |
| src/reverse_api/opencode_engineer.py | Prepares and validates the selected Ollama model before using OpenCode. |
| src/reverse_api/cli.py | Adds Ollama to the OpenCode provider picker and provides installed-model selection. |
| tests/test_ollama_runtime.py | Covers model metadata enrichment, compatibility filtering, daemon startup, provider configuration, and server validation. |

<sub>Reviews (2): Last reviewed commit: ["Load Ollama model metadata from show API"](https://github.com/kalil0321/reverse-api-engineer/commit/f36fbed6c698c7a9fc173ef44f9781976781b498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46294718)</sub>

<!-- /greptile_comment -->