### PR TITLE
[codex] Fix landing rendering and mobile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 1. You give it a website and a goal ("fetch all Apple jobs").
 2. A browser visits the site, either driven by you or by an AI agent.
 3. Network traffic is captured to a HAR file.
-4. Claude reads the traffic and writes you a working API client (Python, JS, or TS).
+4. Your configured model reads the traffic and writes a working API client in Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, or C.
 
 No more manually opening DevTools, copying cURL commands, and gluing together a client.
 

--- a/website/content/docs/cli/commands.mdx
+++ b/website/content/docs/cli/commands.mdx
@@ -35,7 +35,7 @@ Outside the interactive CLI, you can use direct subcommands:
 | `engineer`    | Re-run generation against an existing capture.             |
 | `list`        | List generated scripts and runs; supports `--json`.        |
 | `show`        | Inspect one run; supports `--json`.                        |
-| `run`         | Execute a generated Python script; supports `--json`.      |
+| `run`         | Execute a generated client with its language toolchain.    |
 
 Scripted flags are command-specific: `agent`, `engineer`, and `run` support
 `--json` and `--json-stream`; `list` and `show` support `--json`; and `run`

--- a/website/content/docs/configuration/models.mdx
+++ b/website/content/docs/configuration/models.mdx
@@ -1,9 +1,9 @@
 ---
 title: Model selection
-description: Pick between Claude Sonnet, Opus, and Haiku for API generation.
+description: Choose a model for Claude, OpenCode, Copilot, or Cursor.
 ---
 
-## Available models
+## Claude models
 
 | Model         | When to pick it                                                          |
 |---------------|--------------------------------------------------------------------------|

--- a/website/content/docs/configuration/output.mdx
+++ b/website/content/docs/configuration/output.mdx
@@ -5,11 +5,17 @@ description: Choose the generated client's language and control real-time file s
 
 ## Output language
 
-Generated API clients can be emitted in three languages:
+Generated API clients can be emitted in nine languages:
 
 - **python** *(default)*
 - **javascript**
 - **typescript**
+- **go**
+- **java**
+- **csharp** (C#)
+- **php**
+- **ruby**
+- **c**
 
 Change it in the CLI:
 
@@ -27,6 +33,11 @@ Or in `~/.reverse-api/config.json`:
 
 The generated examples (`example_usage.*`) and README also adapt to the
 chosen language.
+
+Running a generated client requires that language's toolchain. The CLI uses
+Node.js for JavaScript, `npx tsx` for TypeScript, Go, Maven, .NET, PHP, or Ruby
+as appropriate. C output requires a compiler plus libcurl headers (macOS/Linux,
+or WSL/MSYS2 on Windows).
 
 ## Real-time sync
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Introduction
-description: Capture browser traffic and turn it into a production-ready Python API client.
+description: Capture browser traffic and turn it into a production-ready typed API client.
 ---
 
 **Reverse API Engineer** is a CLI tool that captures browser traffic and uses
-your configured AI SDK to generate production-ready Python (or JavaScript /
-TypeScript) API clients. No more manual reverse engineering: browse, capture,
-and get clean API code.
+your configured AI SDK to generate production-ready API clients in Python,
+JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, or C. No more manual reverse
+engineering: browse, capture, and get clean API code.
 
 <Demo
   src="https://raw.githubusercontent.com/kalil0321/reverse-api-engineer/main/assets/rae-autoscout.gif"
@@ -16,7 +16,7 @@ and get clean API code.
 
 <Cards>
   <Card title="Install" href="/docs/installation" description="Get the CLI running in under a minute." />
-  <Card title="Quick start" href="/docs/quick-start" description="From install to a working Python client." />
+  <Card title="Quick start" href="/docs/quick-start" description="From install to a working API client." />
   <Card title="Usage modes" href="/docs/modes/manual" description="Agent, Manual, Engineer, Collector." />
   <Card title="Configuration" href="/docs/configuration/models" description="Models, providers, SDKs, output." />
 </Cards>
@@ -84,7 +84,7 @@ time the run ends, the client is already generated.
 The HAR is fed to your configured SDK model (Claude by default) along with a
 tuned system prompt. Output:
 
-- Typed Python (or TS / JS) clients with docstrings.
+- Typed clients with language-appropriate documentation.
 - Authentication handling: cookies, bearers, CSRF tokens.
 - Pagination helpers, error types, retry-safe operations.
 - A runnable `example_usage.*` and a generated `README.md`.
@@ -114,10 +114,11 @@ Generated scripts include type hints, structured error handling, and inline
 documentation. They're not "demo" snippets; they're meant to be checked into
 your codebase and called from production.
 
-### Output in Python, JavaScript, or TypeScript
+### Output in nine languages
 
-Switch the target language in `/settings`. Same capture, different code.
-Useful when you want the same API client surfaced to multiple stacks.
+Switch between Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C
+in `/settings`. Same capture, different code. Useful when you want the same API
+client surfaced to multiple stacks.
 
 ## Limitations
 

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -62,5 +62,5 @@ working on.
 
 <Cards>
   <Card title="Quick start" href="/docs/quick-start" description="From `pip install` to a working client." />
-  <Card title="Configure your model" href="/docs/configuration/models" description="Pick between Sonnet, Opus, Haiku." />
+  <Card title="Configure your model" href="/docs/configuration/models" description="Choose the model for your selected SDK." />
 </Cards>

--- a/website/content/docs/quick-start.mdx
+++ b/website/content/docs/quick-start.mdx
@@ -33,7 +33,8 @@ description: From a fresh install to a working API client in under five minutes.
     The CLI opens a Chromium window. You browse, click, scroll, search:
     whatever exercises the requests you care about. Close the window when
     done. The AI takes over: it reads the HAR file, identifies the API
-    surface, and emits a typed Python client.
+    surface, and emits a typed client in your configured output language
+    (Python by default).
 
     <Demo
       src="https://raw.githubusercontent.com/kalil0321/reverse-api-engineer/main/assets/reverse-api-engineer.gif"
@@ -45,7 +46,7 @@ description: From a fresh install to a working API client in under five minutes.
   <Step>
     ### Read the output
 
-    Generated scripts are saved in two places:
+    With the default Python output, generated scripts are saved in two places:
 
     <Files>
       <Folder name="~/.reverse-api/runs/scripts/{run_id}" defaultOpen>
@@ -67,7 +68,8 @@ description: From a fresh install to a working API client in under five minutes.
   <Step>
     ### Run the generated client
 
-    The generated script is just Python. Run it like any other:
+    With the default output, the generated script is plain Python. Run it like
+    any other:
 
     ```bash
     python scripts/apple_jobs_api/example_usage.py
@@ -79,6 +81,10 @@ description: From a fresh install to a working API client in under five minutes.
     reverse-api-engineer run <run_id> --file api_client.py \
       --json --auto-install
     ```
+
+    The CLI runner also dispatches JavaScript, TypeScript, Go, Java, C#, PHP,
+    Ruby, and C clients through their installed toolchains. See
+    [Output language & sync](/docs/configuration/output).
   </Step>
 </Steps>
 
@@ -86,6 +92,6 @@ description: From a fresh install to a working API client in under five minutes.
 
 <Cards>
   <Card title="Modes in depth" href="/docs/modes/manual" description="When to use Agent, Manual, Engineer, or Collector." />
-  <Card title="Configure your model" href="/docs/configuration/models" description="Pick between Sonnet, Opus, Haiku." />
+  <Card title="Configure your model" href="/docs/configuration/models" description="Choose the model for your selected SDK." />
   <Card title="Scripted usage" href="/docs/cli/scripted-usage" description="Run from another agent with --json output." />
 </Cards>

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -4,6 +4,10 @@ const config = {
   output: 'export',
   trailingSlash: true,
   images: { unoptimized: true },
+  // Local previews may be opened through 127.0.0.1 even though Next starts
+  // with localhost. Without this, Next blocks the dev client and hydration,
+  // leaving tabs, the theme toggle, and reveal effects inert.
+  allowedDevOrigins: ['127.0.0.1'],
 };
 
 export default config;

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -11,7 +11,7 @@ import { StepBrowse, StepCapture, StepGenerate, StepReview } from '@/components/
 import { JsonLd } from '@/components/json-ld';
 
 const homeDescription =
-  'The agent that turns any website into a typed Python, TypeScript, or JavaScript API client — generated from the requests the site actually makes.';
+  'The agent that turns any website into a typed API client in nine languages — generated from the requests the site actually makes.';
 
 export const metadata: Metadata = {
   title: 'Turn websites into APIs',
@@ -60,7 +60,7 @@ const softwareJsonLd = {
   downloadUrl: pypiUrl,
   codeRepository: githubUrl,
   license: 'https://opensource.org/licenses/MIT',
-  programmingLanguage: ['Python', 'JavaScript', 'TypeScript'],
+  programmingLanguage: ['Python', 'JavaScript', 'TypeScript', 'Go', 'Java', 'C#', 'PHP', 'Ruby', 'C'],
   offers: {
     '@type': 'Offer',
     price: '0',
@@ -96,10 +96,10 @@ function Hero() {
       style={{ position: 'absolute', top: -9, left: '50%', transform: 'translateX(-50%) rotate(-3deg)', width: 58, height: 20, background: 'rgba(245,240,220,0.5)', border: '1px solid rgba(180,175,150,0.35)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }}
     />
   );
-  const note = (bg: string, rot: number, w: number, d: number, children: ReactNode) => (
+  const note = (bg: string, rot: number, w: number, d: number, children: ReactNode, className = '') => (
     <div
-      className="la-note"
-      style={{ position: 'relative', background: bg, width: w, padding: '22px 20px 28px', boxShadow: '0 10px 22px rgba(0,0,0,0.20)', textAlign: 'center', '--r': `${rot}deg`, '--d': `${d}s` } as CSSProperties}
+      className={`la-note ${className}`}
+      style={{ position: 'relative', background: bg, boxShadow: '0 10px 22px rgba(0,0,0,0.20)', textAlign: 'center', '--note-width': `${w}px`, '--r': `${rot}deg`, '--d': `${d}s` } as CSSProperties}
     >
       <Tape />
       {children}
@@ -107,39 +107,41 @@ function Hero() {
   );
 
   return (
-    <section className="relative overflow-hidden bg-cream min-h-[calc(100svh-3.5rem)] flex items-center justify-center px-6 sm:px-10 py-14">
+    <section className="relative flex min-h-[calc(100svh-3.5rem)] items-center justify-center overflow-hidden bg-cream px-4 py-12 sm:px-10 sm:py-14">
       <h1 className="sr-only">Turn websites into APIs.</h1>
 
       <Reveal className="relative z-10">
-        <div className="flex flex-col items-center gap-12">
+        <div className="flex flex-col items-center gap-10 sm:gap-12">
           {/* Neo-brutalist print with the two notes taped on its corners. */}
           <div className="la-rise">
             <div className="relative" style={{ transform: 'rotate(-1.5deg)' }}>
-              <div style={{ width: 'clamp(260px, 62vw, 520px)', background: '#fff', padding: 12, border: '3px solid var(--color-ink)', boxShadow: '10px 10px 0 0 var(--color-fd-primary)' }}>
+              <div className="hero-art-frame">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src="/illustrations/hero-isoB-0.webp" alt="Reverse API Engineer turning a website into a typed client" className="block h-auto w-full" />
+                <img src="/illustrations/hero-isoB-0.webp" alt="Reverse API Engineer turning a website into a typed client" className="hero-art block w-full" />
               </div>
-              <div className="absolute z-10" style={{ top: -26, left: -34 }}>
+              <div className="hero-corner-note hero-corner-note-left absolute z-10">
                 {note('#fff27a', -4, 240, 0.3,
-                  <p className="font-display font-medium" style={{ fontSize: '1.9rem', lineHeight: 1, color: '#1f1f1f', letterSpacing: '-0.02em' }}>Turn websites</p>,
+                  <p className="hero-note-title font-display font-medium" style={{ lineHeight: 1, color: '#1f1f1f', letterSpacing: '-0.02em' }}>Turn websites</p>,
+                  'hero-corner-note-card',
                 )}
               </div>
-              <div className="absolute z-10" style={{ bottom: 24, right: -40 }}>
+              <div className="hero-corner-note hero-corner-note-right absolute z-10">
                 {note('#ffb3d1', 5, 250, 0.45,
-                  <p className="font-display italic font-medium" style={{ fontSize: '1.9rem', lineHeight: 1, color: '#b3005f', letterSpacing: '-0.02em', fontVariationSettings: "'opsz' 144, 'SOFT' 100, 'WONK' 1" }}>into APIs.</p>,
+                  <p className="hero-note-title font-display italic font-medium" style={{ lineHeight: 1, color: '#b3005f', letterSpacing: '-0.02em', fontVariationSettings: "'opsz' 144, 'SOFT' 100, 'WONK' 1" }}>into APIs.</p>,
+                  'hero-corner-note-card',
                 )}
               </div>
             </div>
           </div>
 
-          {note('var(--color-fd-card)', 2, 360, 0.6, <InstallCommand />)}
+          {note('var(--color-fd-card)', 2, 360, 0.6, <InstallCommand />, 'hero-install-note')}
 
-          <div className="la-rise inline-flex flex-wrap items-center justify-center gap-3" style={{ '--d': '0.7s' } as CSSProperties}>
-            <Link href="/docs" className="btn-primary">
+          <div className="la-rise inline-flex w-full flex-wrap items-center justify-center gap-3 sm:w-auto" style={{ '--d': '0.7s' } as CSSProperties}>
+            <Link href="/docs" className="btn-primary w-full justify-center sm:w-auto">
               Read the docs
               <ArrowRightIcon className="size-4" />
             </Link>
-            <Link href={githubUrl} target="_blank" className="btn-secondary">
+            <Link href={githubUrl} target="_blank" className="btn-secondary w-full justify-center sm:w-auto">
               <GithubIcon className="size-4" />
               View on GitHub
             </Link>
@@ -163,20 +165,20 @@ const HIW_ROT = ['-rotate-3', 'rotate-2', '-rotate-2', 'rotate-3'];
 
 function HowItWorks() {
   return (
-    <section className="bg-orange relative overflow-hidden min-h-[100svh] flex items-center">
-      <div className="relative w-full mx-auto max-w-7xl px-6 lg:px-10 py-24 md:py-32">
+    <section className="relative flex items-center overflow-hidden bg-orange md:min-h-[100svh]">
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 md:py-32 lg:px-10">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="section-display mt-3">How it works?</h2>
         </div>
 
         {/* Polaroid wall — each step is an instant photo, pinned with tape. */}
         <Reveal>
-          <div className="mt-14 md:mt-16 flex flex-wrap items-start justify-center gap-7">
+          <div className="mt-10 grid grid-cols-2 items-start gap-4 sm:mt-14 sm:flex sm:flex-wrap sm:justify-center sm:gap-7 md:mt-16">
             {HIW_STEPS.map(({ Ill, title, body }, i) => (
               <div key={title} className="hiw-pol-wrap" style={{ '--d': `${i * 0.12}s` } as CSSProperties}>
-                <div className={`${HIW_ROT[i]} bg-white p-2.5 pb-0 shadow-[0_14px_30px_rgba(0,0,0,0.16)] transition-transform duration-200 hover:-translate-y-2 hover:rotate-0`} style={{ width: 184 }}>
-                  <div className="grid h-36 place-items-center" style={{ background: HIW_TINT[i] }}>
-                    <div className="w-[112px]"><Ill /></div>
+                <div className={`${HIW_ROT[i]} w-full bg-white p-2 pb-0 shadow-[0_14px_30px_rgba(0,0,0,0.16)] transition-transform duration-200 hover:-translate-y-2 hover:rotate-0 sm:w-[184px] sm:p-2.5 sm:pb-0`}>
+                  <div className="grid h-28 place-items-center sm:h-36" style={{ background: HIW_TINT[i] }}>
+                    <div className="w-[84px] sm:w-[112px]"><Ill /></div>
                   </div>
                   <div className="py-4 text-center">
                     <p className="font-display italic text-xl" style={{ color: '#1f1f1f', fontVariationSettings: "'opsz' 144, 'SOFT' 100, 'WONK' 1" }}>{title}</p>
@@ -196,7 +198,7 @@ function HowItWorks() {
 
 function FinalCTA() {
   return (
-    <section className="relative overflow-hidden bg-sky min-h-[100svh] flex items-center">
+    <section className="relative flex items-center overflow-hidden bg-sky md:min-h-[100svh]">
       <div className="absolute inset-0 bg-scanlines pointer-events-none" />
       <span
         aria-hidden="true"
@@ -211,7 +213,7 @@ function FinalCTA() {
         *
       </span>
 
-      <div className="relative w-full mx-auto max-w-6xl px-6 lg:px-10 py-28 md:py-40">
+      <div className="relative mx-auto w-full max-w-6xl px-4 py-20 sm:px-6 sm:py-28 md:py-40 lg:px-10">
         <Reveal>
           <div className="grid md:grid-cols-[1.1fr_1fr] gap-12 md:gap-16 items-center">
             {/* Left: headline + CTAs */}
@@ -222,12 +224,12 @@ function FinalCTA() {
               <p className="mt-8 max-w-md text-base md:text-lg text-ink-soft leading-relaxed">
                 Install. Prompt. Get your typed client back.
               </p>
-              <div className="mt-10 inline-flex flex-wrap items-center gap-3">
-                <Link href="/docs/quick-start" className="btn-primary">
+              <div className="mt-10 inline-flex w-full flex-wrap items-center gap-3 sm:w-auto">
+                <Link href="/docs/quick-start" className="btn-primary w-full justify-center sm:w-auto">
                   Get started
                   <ArrowRightIcon className="size-4" />
                 </Link>
-                <Link href={githubUrl} target="_blank" className="btn-secondary">
+                <Link href={githubUrl} target="_blank" className="btn-secondary w-full justify-center sm:w-auto">
                   <GithubIcon className="size-4" />
                   View on GitHub
                 </Link>
@@ -274,7 +276,7 @@ function PostItCard() {
   return (
     <div
       className="justify-self-center"
-      style={{ position: 'relative', width: 'clamp(260px, 34vw, 340px)', background: '#c4edd0', padding: '40px 30px 34px', transform: 'rotate(-3deg)', boxShadow: '0 18px 40px rgba(0,0,0,0.26), 0 4px 10px rgba(0,0,0,0.14)' }}
+      style={{ position: 'relative', width: 'min(340px, calc(100vw - 3rem))', background: '#c4edd0', padding: '40px 30px 34px', transform: 'rotate(-3deg)', boxShadow: '0 18px 40px rgba(0,0,0,0.26), 0 4px 10px rgba(0,0,0,0.14)' }}
     >
       <span
         aria-hidden

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -278,6 +278,38 @@ body {
   50% { transform: rotate(calc(var(--r, 0deg) + 1.3deg)); }
 }
 
+.la-note {
+  width: min(var(--note-width, 22.5rem), calc(100vw - 2rem));
+  padding: 1.375rem 1.25rem 1.75rem;
+}
+
+.hero-art-frame {
+  width: clamp(16.25rem, 62vw, 32.5rem);
+  padding: 0.75rem;
+  border: 3px solid var(--color-ink);
+  background: #fff;
+  box-shadow: 10px 10px 0 0 var(--color-fd-primary);
+}
+
+.hero-art {
+  height: auto;
+}
+
+.hero-corner-note-left { top: -1.625rem; left: -2.125rem; }
+.hero-corner-note-right { right: -2.5rem; bottom: 1.5rem; }
+.hero-note-title { font-size: 1.9rem; }
+
+@media (max-width: 39.999rem) {
+  .la-note { padding: 1rem 0.9rem 1.2rem; }
+  .hero-art-frame { width: min(82vw, 22rem); padding: 0.5rem; box-shadow: 7px 7px 0 0 var(--color-fd-primary); }
+  .hero-art { aspect-ratio: 4 / 3; object-fit: cover; object-position: center; }
+  .hero-corner-note-card { width: min(var(--note-width), 56vw); }
+  .hero-corner-note-left { top: -1.125rem; left: -0.75rem; }
+  .hero-corner-note-right { right: -0.75rem; bottom: 0.75rem; }
+  .hero-note-title { font-size: clamp(1.15rem, 6vw, 1.55rem); }
+  .hero-install-note { width: calc(100vw - 2rem); }
+}
+
 [data-show="false"] .la-rise { opacity: 0; transform: translateY(18px); }
 [data-show="false"] .la-note { opacity: 0; }
 

--- a/website/src/app/llms.txt/route.ts
+++ b/website/src/app/llms.txt/route.ts
@@ -15,7 +15,7 @@ export function GET() {
 
 > ${appTagline}
 
-${appName} is an open-source CLI that captures browser traffic with Playwright (or Chrome DevTools MCP) and uses your configured AI SDK to generate a typed Python, JavaScript, or TypeScript API client from the recorded HAR.
+${appName} is an open-source CLI that captures browser traffic with Playwright (or Chrome DevTools MCP) and uses your configured AI SDK to generate a typed API client from the recorded HAR. Output languages: Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C.
 
 ## Documentation
 

--- a/website/src/components/built-in-the-open.tsx
+++ b/website/src/components/built-in-the-open.tsx
@@ -12,14 +12,14 @@ const CARDS = [
   {
     id: '003',
     title: 'You own the output',
-    note: 'rae writes plain Python files straight into your project. No SDK to depend on, no service that can go away — just code you can read and edit.',
+    note: 'rae writes plain source files straight into your project. No SDK to depend on, no service that can go away — just code you can read and edit.',
   },
 ];
 
 export function BuiltInTheOpen() {
   return (
-    <section className="bg-[#e8e3f0] dark:bg-[#15101e] min-h-[100svh] flex items-center">
-      <div className="w-full mx-auto max-w-7xl px-6 lg:px-10 py-24 md:py-36">
+    <section className="flex items-center bg-[#e8e3f0] dark:bg-[#15101e] md:min-h-[100svh]">
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 md:py-36 lg:px-10">
         <div className="mb-12 md:mb-14 flex justify-end">
           <div className="text-right max-w-2xl">
             <h2

--- a/website/src/components/install-command.tsx
+++ b/website/src/components/install-command.tsx
@@ -21,11 +21,11 @@ export function InstallCommand() {
   return (
     <button
       onClick={copy}
-      className="inline-flex items-center gap-2 cursor-pointer group"
+      className="group inline-flex w-full cursor-pointer items-center justify-center gap-1.5 sm:gap-2"
       aria-label="Copy install command to clipboard"
     >
       <span className="font-mono text-xs text-fd-primary select-none">$</span>
-      <code className="font-mono text-xs text-ink-soft tracking-wide select-none group-hover:text-ink transition-colors duration-150">
+      <code className="select-none whitespace-nowrap font-mono text-[10px] tracking-tight text-ink-soft transition-colors duration-150 group-hover:text-ink sm:text-xs sm:tracking-wide">
         {COMMAND}
       </code>
       <span className="flex-shrink-0 w-3">

--- a/website/src/components/reveal.tsx
+++ b/website/src/components/reveal.tsx
@@ -1,40 +1,10 @@
-'use client';
-
-import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
-/* Flips data-show to "true" the first time it scrolls into view, so CSS
-   entrance animations (e.g. the polaroid rise, the sticky-note drop) play on
-   entry rather than on load. Reduced-motion is handled in the CSS. */
+/* Keep landing content visible in the server-rendered HTML. Entrance motion is
+   decorative; images and copy must not depend on hydration or observers. */
 export function Reveal({ children, className }: { children: ReactNode; className?: string }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [show, setShow] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (typeof IntersectionObserver === 'undefined') {
-      setShow(true);
-      return;
-    }
-    const io = new IntersectionObserver(
-      (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            setShow(true);
-            io.disconnect();
-            break;
-          }
-        }
-      },
-      { threshold: 0.2 },
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, []);
-
   return (
-    <div ref={ref} data-show={show ? 'true' : 'false'} className={className}>
+    <div data-show="true" className={className}>
       {children}
     </div>
   );

--- a/website/src/components/site-nav.tsx
+++ b/website/src/components/site-nav.tsx
@@ -17,7 +17,7 @@ export function SiteNav() {
       className="sticky top-0 z-50 backdrop-blur-xl backdrop-saturate-150"
       style={{ backgroundColor: 'color-mix(in oklch, var(--color-cream) 58%, transparent)' }}
     >
-      <div className="mx-auto max-w-7xl px-6 lg:px-10 h-14 flex items-center justify-between">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-10">
         <Link href="/" className="flex items-baseline gap-1.5 group">
           <span
             className="font-display select-none leading-none inline-block italic transition-transform group-hover:rotate-12"

--- a/website/src/components/works-with-agents.tsx
+++ b/website/src/components/works-with-agents.tsx
@@ -16,13 +16,13 @@ export function WorksWithAgents() {
         *
       </span>
 
-      <div className="relative mx-auto max-w-7xl px-6 lg:px-10 py-24 md:py-32">
+      <div className="relative mx-auto max-w-7xl px-4 py-20 sm:px-6 sm:py-24 md:py-32 lg:px-10">
         {/* Split-flap board — the board itself stays dark (like a real
             departure display) so it reads as a physical object on any page bg. */}
-        <div className="mx-auto max-w-2xl space-y-2.5 rounded-2xl bg-[#0d0a07] p-6 md:p-8 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.5)]">
+        <div className="mx-auto max-w-2xl space-y-2.5 rounded-xl bg-[#0d0a07] p-4 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.5)] sm:rounded-2xl sm:p-6 md:p-8">
           <div className="flex items-center justify-between px-1 pb-1 font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">
             <span>agent</span>
-            <span>status</span>
+            <span className="hidden sm:inline">status</span>
           </div>
           {AGENTS.map((a, ai) => (
             <div key={a.key} className="flex items-center gap-3">
@@ -30,7 +30,10 @@ export function WorksWithAgents() {
                 <BrandIcon agent={a} className="size-4 text-white/85" />
               </span>
               {/* flap tiles spelling the agent name */}
-              <div className="flex gap-px" style={{ perspective: '420px' }}>
+              <span className="min-w-0 truncate font-mono text-xs tracking-[0.08em] text-white/90 sm:hidden">
+                {a.name.toUpperCase()}
+              </span>
+              <div className="hidden gap-px sm:flex" style={{ perspective: '420px' }}>
                 {a.name.toUpperCase().slice(0, 16).split('').map((ch, ci) => (
                   <span
                     key={ci}
@@ -41,7 +44,7 @@ export function WorksWithAgents() {
                   </span>
                 ))}
               </div>
-              <span className="ml-auto shrink-0 font-mono text-[11px] text-fd-primary">SUPPORTED</span>
+              <span className="ml-auto hidden shrink-0 font-mono text-[11px] text-fd-primary sm:inline">SUPPORTED</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## What changed

- keep landing-page imagery and content visible in server-rendered HTML
- make the hero, agent board, workflow cards, and CTAs responsive on mobile
- allow `127.0.0.1` to load the Next.js dev client so theme and docs tabs hydrate locally
- document all nine supported output languages across the site, README, and `llms.txt`

## Why

Landing visuals depended on a client-side intersection observer, so hydration problems could leave important content hidden. Local previews opened through `127.0.0.1` were also blocked by Next's dev-origin protection, which made the theme switch and installation tabs inert even though the deployed static site worked.

## Impact

The landing page is visible before JavaScript runs, fits narrow screens without clipped notes or controls, and local development behaves like the deployed site. Documentation now matches the CLI's actual Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C output support.

## Validation

- `npm run types:check`
- `npm run build`
- local verification of hero imagery, theme switching, and installation tabs

`npm run lint` is currently blocked before linting project files by the repository's existing ESLint 10 / `eslint-plugin-react` compatibility error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes landing-page rendering so imagery and copy are visible before JS, and makes the hero, workflow cards, agent board, and CTAs responsive on mobile. Also enables local hydration via 127.0.0.1 and updates docs to list all nine output languages.

- **Bug Fixes**
  - Keep landing visuals in server HTML; remove intersection-observer gating so content isn’t hidden pre-hydration.
  - Improve mobile layout: hero art/notes, install button, workflow “polaroids,” agent board, CTAs, and nav spacing.
  - Allow `127.0.0.1` in `Next.js` dev (`allowedDevOrigins`) so the theme toggle and docs tabs hydrate locally.

- **Documentation**
  - Document nine output languages across the site, README, and `llms.txt` (Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, C).
  - Clarify that `run` executes the generated client with its language toolchain and note toolchain requirements.

<sup>Written for commit 789d4e257b1f3ddd1cc35f983c4152cbae08c33f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves landing-page rendering, mobile layout, local development, and language documentation. The main changes are:

- Keeps landing content visible in server-rendered HTML.
- Makes hero artwork, workflow cards, agent details, and calls to action responsive.
- Allows `127.0.0.1` to load the Next.js development client.
- Documents all nine supported output languages.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| website/src/components/reveal.tsx | Removes client-side visibility gating so landing content is present and visible in server-rendered HTML. |
| website/src/app/(home)/page.tsx | Adds responsive hero, workflow, call-to-action, and post-it layouts while expanding language metadata. |
| website/src/app/global.css | Adds narrow-screen sizing and positioning rules for the hero artwork and notes. |
| website/next.config.mjs | Allows `127.0.0.1` to load the Next.js development client. |
| website/src/components/works-with-agents.tsx | Uses a compact mobile presentation for the agent board. |
| website/src/components/install-command.tsx | Adjusts the install command control for narrow screens. |

<sub>Reviews (2): Last reviewed commit: ["Fix landing page rendering and docs"](https://github.com/kalil0321/reverse-api-engineer/commit/789d4e257b1f3ddd1cc35f983c4152cbae08c33f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46321501)</sub>

<!-- /greptile_comment -->