### PR TITLE
Make Playwright an optional [manual] extra to slim the base install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Playwright is now an optional `[manual]` extra**: agent mode (the default) captures through browser MCP servers over `npx` and never imports the Python Playwright package, so `playwright` and `playwright-stealth` moved out of the base dependencies into a `[manual]` optional-dependency group. This keeps the base install (and any runtime that bundles the package) lightweight. Manual capture mode now requires `pip install "reverse-api-engineer[manual]"`; running it without the extra prints an actionable install hint instead of an import error.
+
 ## [0.11.0] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Playwright is now an optional `[manual]` extra**: agent mode (the default) captures through browser MCP servers over `npx` and never imports the Python Playwright package, so `playwright` and `playwright-stealth` moved out of the base dependencies into a `[manual]` optional-dependency group. This keeps the base install (and any runtime that bundles the package) lightweight. Manual capture mode now requires `pip install "reverse-api-engineer[manual]"` followed by `playwright install chromium`. Entering manual mode without the extra fails fast — before any run is recorded — with an actionable hint listing both steps, so a base-only install never leaves a phantom `manual` run in history.
+- **Playwright is now an optional `[manual]` extra**: agent mode (the default) captures through `npx`-launched browser tooling (browser MCP servers or the `agent-browser` CLI) and never imports the Python Playwright package, so `playwright` and `playwright-stealth` moved out of the base dependencies into a `[manual]` optional-dependency group. This keeps the base install (and any runtime that bundles the package) lightweight. Manual capture mode now requires `pip install "reverse-api-engineer[manual]"` followed by `playwright install chromium`. Entering manual mode without the extra fails fast — before any run is recorded — with an actionable hint listing both steps, so a base-only install never leaves a phantom `manual` run in history.
 
 ## [0.11.0] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Playwright is now an optional `[manual]` extra**: agent mode (the default) captures through browser MCP servers over `npx` and never imports the Python Playwright package, so `playwright` and `playwright-stealth` moved out of the base dependencies into a `[manual]` optional-dependency group. This keeps the base install (and any runtime that bundles the package) lightweight. Manual capture mode now requires `pip install "reverse-api-engineer[manual]"`; running it without the extra prints an actionable install hint instead of an import error.
+- **Playwright is now an optional `[manual]` extra**: agent mode (the default) captures through browser MCP servers over `npx` and never imports the Python Playwright package, so `playwright` and `playwright-stealth` moved out of the base dependencies into a `[manual]` optional-dependency group. This keeps the base install (and any runtime that bundles the package) lightweight. Manual capture mode now requires `pip install "reverse-api-engineer[manual]"` followed by `playwright install chromium`. Entering manual mode without the extra fails fast — before any run is recorded — with an actionable hint listing both steps, so a base-only install never leaves a phantom `manual` run in history.
 
 ## [0.11.0] - 2026-07-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ Thank you for your interest in contributing! This document provides guidelines a
 
 2. **Install dependencies**
    ```bash
-   uv sync
-   playwright install chromium
+   uv sync --all-extras
+   playwright install chromium   # for manual-mode capture (Playwright ships in the [manual] extra)
    ```
 
 3. **Run locally**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing! This document provides guidelines a
 2. **Install dependencies**
    ```bash
    uv sync --all-extras
-   playwright install chromium   # for manual-mode capture (Playwright ships in the [manual] extra)
+   uv run playwright install chromium   # for manual-mode capture (Playwright ships in the [manual] extra)
    ```
 
 3. **Run locally**

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ No more manually opening DevTools, copying cURL commands, and gluing together a 
 
 ```bash
 uv tool install reverse-api-engineer   # or: pip install reverse-api-engineer
+```
+
+Agent mode (the default) captures through browser MCP servers over `npx` and
+needs no extra Python packages. **Manual mode** drives a local Playwright
+browser, which ships in the optional `[manual]` extra:
+
+```bash
+uv tool install "reverse-api-engineer[manual]"   # or: pip install "reverse-api-engineer[manual]"
 playwright install chromium
 ```
 
@@ -177,7 +185,7 @@ uv sync
 uv run reverse-api-engineer
 ```
 
-Build: `./scripts/clean_build.sh`. Requires Python 3.11+, Playwright browsers, and an API key for agent mode.
+Build: `./scripts/clean_build.sh`. Requires Python 3.11+ and an API key for agent mode. Manual mode additionally needs the `[manual]` extra plus `playwright install chromium`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ No more manually opening DevTools, copying cURL commands, and gluing together a 
 uv tool install reverse-api-engineer   # or: pip install reverse-api-engineer
 ```
 
-Agent mode (the default) captures through browser MCP servers over `npx` and
-needs no extra Python packages. **Manual mode** drives a local Playwright
-browser, which ships in the optional `[manual]` extra:
+Agent mode (the default) captures through `npx`-launched browser tooling —
+browser MCP servers (Playwright or Chrome DevTools) or the Vercel `agent-browser`
+CLI — and needs no extra Python packages. **Manual mode** drives a local
+Playwright browser, which ships in the optional `[manual]` extra:
 
 ```bash
 uv tool install "reverse-api-engineer[manual]"   # or: pip install "reverse-api-engineer[manual]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "playwright>=1.40.0",
-    "playwright-stealth>=1.0.0",
     "click>=8.1.0",
     "claude-agent-sdk>=0.1.48",
     "rich>=13.0.0",
@@ -59,6 +57,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Manual capture mode drives a local Playwright browser. Agent mode (the
+# default) uses external MCP servers over npx and needs none of this, so the
+# heavy browser stack is opt-in — keeping the base install lightweight.
+manual = [
+    "playwright>=1.40.0",
+    "playwright-stealth>=1.0.0",
+]
 collector = [
     "markdownify>=0.12.0",
     "beautifulsoup4>=4.12.0",

--- a/src/reverse_api/browser.py
+++ b/src/reverse_api/browser.py
@@ -226,6 +226,37 @@ class ManualBrowser:
         """Inject stealth scripts into page before any other scripts run."""
         page.add_init_script(STEALTH_JS)
 
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        """Prepend https:// when the user typed a bare host (e.g.
+        ``jobs.example.com/x``); Playwright's goto rejects scheme-less URLs."""
+        url = url.strip()
+        if url and "://" not in url:
+            return "https://" + url
+        return url
+
+    def _abort_playwright(self) -> None:
+        """Quietly tear down the browser/Playwright after a failed start.
+
+        Unlike close(), this saves nothing and prints nothing — its only job is
+        to stop the sync-Playwright event loop so it doesn't leak into the
+        caller. A leaked loop makes the caller's next asyncio.run() (the REPL
+        prompt) fail with "asyncio.run() cannot be called from a running event
+        loop". Safe to call with partially-initialized state.
+        """
+        for teardown in (
+            lambda: self._context and self._context.close(),
+            lambda: self._browser and not self._using_persistent and self._browser.close(),
+            lambda: self._playwright and self._playwright.stop(),
+        ):
+            try:
+                teardown()
+            except Exception:
+                pass
+        self._context = None
+        self._browser = None
+        self._playwright = None
+
     def _start_with_real_chrome(self, start_url: str | None = None) -> Path:
         """Start using the real Chrome browser with user's profile."""
         import shutil
@@ -393,14 +424,24 @@ class ManualBrowser:
         console.print(" [dim]close browser or ctrl+c to finalize[/dim]")
         console.print()
 
+        if start_url:
+            start_url = self._normalize_url(start_url)
+
         self._playwright = sync_playwright().start()
 
         # Try real Chrome first (better for avoiding detection)
         # Fall back to stealth Chromium if Chrome not available
-        if self.use_real_chrome:
-            return self._start_with_real_chrome(start_url)
-        else:
-            return self._start_with_stealth_chromium(start_url)
+        try:
+            if self.use_real_chrome:
+                return self._start_with_real_chrome(start_url)
+            else:
+                return self._start_with_stealth_chromium(start_url)
+        except Exception:
+            # Startup failed (e.g. an invalid URL) before close() could stop
+            # Playwright. Tear it down here so its sync event loop doesn't leak
+            # and break the caller's next asyncio.run() (the REPL prompt).
+            self._abort_playwright()
+            raise
 
     def close(self) -> Path:
         """Close the browser and save HAR file. Returns HAR path."""

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -17,6 +17,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style as PtStyle
 from questionary import Choice
 from rich.console import Console
+from rich.markup import escape
 
 from . import __version__
 from .config import DEFAULT_OPENCODE_MODEL, DEFAULT_OPENCODE_PROVIDER, ConfigManager
@@ -69,7 +70,7 @@ def _select_ollama_model_for_settings() -> str | None:
     try:
         status = asyncio.run(ensure_ollama_models())
     except OllamaSetupError as e:
-        console.print(f" [yellow]error:[/yellow] {e}\n")
+        console.print(f" [yellow]error:[/yellow] {escape(str(e))}\n")
         return None
 
     models = status.compatible_models
@@ -153,7 +154,7 @@ def _select_opencode_pair_for_settings(mode_color=THEME_PRIMARY) -> tuple[str, s
                 "Set OPENCODE_SERVER_PASSWORD (and OPENCODE_SERVER_USERNAME when customized).\n"
             )
         else:
-            console.print(f" [yellow]error:[/yellow] could not load OpenCode providers and models: {e}\n")
+            console.print(f" [yellow]error:[/yellow] could not load OpenCode providers and models: {escape(str(e))}\n")
         return None
 
     providers = [provider for provider in catalog.get("providers", []) if isinstance(provider, dict)]
@@ -1148,7 +1149,7 @@ def repl_loop():
             console.print("\n [dim]terminated[/dim]")
             return
         except Exception as e:
-            console.print(f" [red]error:[/red] {e}")
+            console.print(f" [red]error:[/red] {escape(str(e))}")
             console.print(f" [dim]{ERROR_CTA}[/dim]")
 
 
@@ -1631,7 +1632,7 @@ def handle_messages(run_id: str, mode_color=THEME_PRIMARY):
                 display += "..."
             console.print(f" [dim]{timestamp}  .. {display}[/dim]")
         elif msg_type == "error":
-            console.print(f" [dim]{timestamp}[/dim] [red]error: {content}[/red]")
+            console.print(f" [dim]{timestamp}[/dim] [red]error: {escape(str(content))}[/red]")
         elif msg_type == "result":
             console.print(f" [dim]{timestamp}[/dim] [white]complete[/white]")
             if isinstance(content, dict):
@@ -1991,7 +1992,7 @@ def run_collector(prompt=None, model=None, output_dir=None):
             )
         return result
     except Exception as e:
-        console.print(f" [red]collector error: {e}[/red]")
+        console.print(f" [red]collector error: {escape(str(e))}[/red]")
         console.print(f" [dim]{ERROR_CTA}[/dim]")
         import traceback
 
@@ -2197,7 +2198,7 @@ def run_auto_capture(
         }
 
     except Exception as e:
-        console.print(f" [red]auto mode error: {e}[/red]")
+        console.print(f" [red]auto mode error: {escape(str(e))}[/red]")
         console.print(f" [dim]{ERROR_CTA}[/dim]")
         import traceback
 

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -1841,6 +1841,20 @@ def run_manual_capture(prompt=None, url=None, reverse_engineer=True, model=None,
     """Shared logic for manual capture."""
     output_dir = output_dir or config_manager.get("output_dir")
 
+    # Manual mode drives a local Playwright browser, which ships in the optional
+    # [manual] extra. Fail fast — before prompting the user or recording a run —
+    # so a base-only install never leaves a phantom "manual" run in history.
+    try:
+        from .browser import ManualBrowser
+    except ImportError as exc:
+        raise click.ClickException(
+            "Manual capture mode requires the Playwright browser stack, which is "
+            "not installed by default. Install it with:\n\n"
+            "    pip install 'reverse-api-engineer[manual]'\n"
+            "    playwright install chromium\n\n"
+            "(Agent mode does not need this.)"
+        ) from exc
+
     if prompt is None:
         options = prompt_interactive_options(
             prompt=prompt,
@@ -1870,16 +1884,6 @@ def run_manual_capture(prompt=None, url=None, reverse_engineer=True, model=None,
         sdk=sdk,
         paths={"har_dir": str(get_har_dir(run_id, output_dir))},
     )
-
-    try:
-        from .browser import ManualBrowser
-    except ImportError as exc:
-        raise click.ClickException(
-            "Manual capture mode requires the Playwright browser stack, which is "
-            "not installed by default. Install it with:\n\n"
-            "    pip install 'reverse-api-engineer[manual]'\n\n"
-            "(Agent mode does not need this.)"
-        ) from exc
 
     browser = ManualBrowser(run_id=run_id, prompt=prompt, output_dir=output_dir)
     har_path = browser.start(start_url=url)

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -19,7 +19,6 @@ from questionary import Choice
 from rich.console import Console
 
 from . import __version__
-from .browser import ManualBrowser
 from .config import DEFAULT_OPENCODE_MODEL, DEFAULT_OPENCODE_PROVIDER, ConfigManager
 from .engineer import run_reverse_engineering
 from .messages import MessageStore
@@ -1871,6 +1870,16 @@ def run_manual_capture(prompt=None, url=None, reverse_engineer=True, model=None,
         sdk=sdk,
         paths={"har_dir": str(get_har_dir(run_id, output_dir))},
     )
+
+    try:
+        from .browser import ManualBrowser
+    except ImportError as exc:
+        raise click.ClickException(
+            "Manual capture mode requires the Playwright browser stack, which is "
+            "not installed by default. Install it with:\n\n"
+            "    pip install 'reverse-api-engineer[manual]'\n\n"
+            "(Agent mode does not need this.)"
+        ) from exc
 
     browser = ManualBrowser(run_id=run_id, prompt=prompt, output_dir=output_dir)
     har_path = browser.start(start_url=url)

--- a/tests/test_cli_manual_missing_extra.py
+++ b/tests/test_cli_manual_missing_extra.py
@@ -6,11 +6,14 @@ base-only install, entering manual mode must raise an actionable install hint
 history that later "operate on the latest run" flows could target.
 """
 
+import io
 import sys
 from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from rich.console import Console
+from rich.markup import escape
 
 from reverse_api.cli import run_manual_capture
 
@@ -41,3 +44,17 @@ class TestManualModeMissingExtra:
     def test_records_no_run(self):
         _, mock_session = self._run()
         mock_session.add_run.assert_not_called()
+
+    def test_extra_name_survives_rich_rendering(self):
+        """The CLI prints errors through Rich, which parses `[manual]` as a
+        markup tag and would drop it — leaving `pip install
+        'reverse-api-engineer'` (wrong). The render path must escape the message
+        so the extra name reaches the user intact.
+        """
+        err, _ = self._run()
+        buf = io.StringIO()
+        # Mirror the REPL error handler: exception text into a markup string.
+        Console(file=buf, force_terminal=False, no_color=True).print(
+            f" [red]error:[/red] {escape(str(err))}"
+        )
+        assert "reverse-api-engineer[manual]" in buf.getvalue()

--- a/tests/test_cli_manual_missing_extra.py
+++ b/tests/test_cli_manual_missing_extra.py
@@ -1,0 +1,43 @@
+"""Manual mode must fail fast when the optional ``[manual]`` extra is absent.
+
+Playwright moved out of the base install into the ``[manual]`` extra. On a
+base-only install, entering manual mode must raise an actionable install hint
+*before* recording anything — otherwise it leaves a phantom ``manual`` run in
+history that later "operate on the latest run" flows could target.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from reverse_api.cli import run_manual_capture
+
+
+class TestManualModeMissingExtra:
+    def _run(self):
+        # `sys.modules[name] = None` makes `from .browser import ...` raise
+        # ImportError, simulating a base-only install without Playwright.
+        with patch.dict(sys.modules, {"reverse_api.browser": None}), patch(
+            "reverse_api.cli.session_manager"
+        ) as mock_session:
+            with pytest.raises(click.ClickException) as excinfo:
+                run_manual_capture(
+                    prompt="fetch things",
+                    url="http://example.com",
+                    reverse_engineer=False,
+                    output_dir="/tmp/rae-test-does-not-matter",
+                )
+            return excinfo.value, mock_session
+
+    def test_raises_actionable_hint(self):
+        err, _ = self._run()
+        message = err.format_message()
+        assert "reverse-api-engineer[manual]" in message
+        # The pip command alone is insufficient — Chromium must also be fetched.
+        assert "playwright install chromium" in message
+
+    def test_records_no_run(self):
+        _, mock_session = self._run()
+        mock_session.add_run.assert_not_called()

--- a/tests/test_manual_browser_startup_failure.py
+++ b/tests/test_manual_browser_startup_failure.py
@@ -1,0 +1,41 @@
+"""A failed manual-capture start must not leak Playwright's event loop.
+
+ManualBrowser.start() calls sync_playwright().start() and only stops it inside
+close() on the happy path. If startup fails first (e.g. a bad URL makes
+page.goto raise), Playwright's sync API leaves an asyncio loop running; the
+REPL's next prompt then dies forever with "asyncio.run() cannot be called from
+a running event loop". start() must stop Playwright before propagating.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("playwright")  # ships in the [manual] extra only
+
+from reverse_api.browser import ManualBrowser  # noqa: E402
+
+
+def _browser(tmp_path):
+    return ManualBrowser(run_id="testrun", prompt="grab jobs", output_dir=str(tmp_path))
+
+
+class TestStartupFailureCleanup:
+    def test_playwright_stopped_when_start_raises(self, tmp_path):
+        browser = _browser(tmp_path)
+        fake_pw = MagicMock()
+
+        with patch("reverse_api.browser.sync_playwright") as sp, patch.object(
+            browser, "_start_with_real_chrome", side_effect=RuntimeError("bad URL")
+        ):
+            sp.return_value.start.return_value = fake_pw
+            with pytest.raises(RuntimeError, match="bad URL"):
+                browser.start(start_url="https://example.com")
+
+        fake_pw.stop.assert_called_once()
+        assert browser._playwright is None
+
+    def test_scheme_added_to_bare_host(self):
+        assert ManualBrowser._normalize_url("jobs.example.com/x") == "https://jobs.example.com/x"
+        assert ManualBrowser._normalize_url("http://a.com") == "http://a.com"
+        assert ManualBrowser._normalize_url("  https://b.com  ") == "https://b.com"

--- a/uv.lock
+++ b/uv.lock
@@ -1558,15 +1558,13 @@ wheels = [
 
 [[package]]
 name = "reverse-api-engineer"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "claude-agent-sdk" },
     { name = "click" },
     { name = "cryptography" },
-    { name = "playwright" },
-    { name = "playwright-stealth" },
     { name = "pygments" },
     { name = "questionary" },
     { name = "requests" },
@@ -1582,6 +1580,10 @@ collector = [
 ]
 copilot = [
     { name = "github-copilot-sdk" },
+]
+manual = [
+    { name = "playwright" },
+    { name = "playwright-stealth" },
 ]
 
 [package.dev-dependencies]
@@ -1602,8 +1604,8 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = ">=0.1.0" },
     { name = "markdownify", marker = "extra == 'collector'", specifier = ">=0.12.0" },
-    { name = "playwright", specifier = ">=1.40.0" },
-    { name = "playwright-stealth", specifier = ">=1.0.0" },
+    { name = "playwright", marker = "extra == 'manual'", specifier = ">=1.40.0" },
+    { name = "playwright-stealth", marker = "extra == 'manual'", specifier = ">=1.0.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.33.0" },
@@ -1611,7 +1613,7 @@ requires-dist = [
     { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "watchdog", specifier = ">=3.0.0" },
 ]
-provides-extras = ["collector", "copilot"]
+provides-extras = ["manual", "collector", "copilot"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -60,9 +60,10 @@ and `run` can stream NDJSON progress with `--json-stream`, and `list` plus
 
 ### Browser automation with stealth
 
-Built on **Playwright** with anti-detection patches and viewport
-randomisation. Captures every request as HAR: headers, cookies, request
-bodies, response bodies, timing.
+Manual mode drives a local **Playwright** browser (optional `[manual]` extra)
+with anti-detection patches and viewport randomisation; agent mode captures
+through browser MCP servers. Either way, every request is recorded as HAR:
+headers, cookies, request bodies, response bodies, timing.
 
 ### Autonomous agent loop
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -61,9 +61,11 @@ and `run` can stream NDJSON progress with `--json-stream`, and `list` plus
 ### Browser automation with stealth
 
 Manual mode drives a local **Playwright** browser (optional `[manual]` extra)
-with anti-detection patches and viewport randomisation; agent mode captures
-through browser MCP servers. Either way, every request is recorded as HAR:
-headers, cookies, request bodies, response bodies, timing.
+with anti-detection patches and viewport randomisation, recording every request
+as a HAR file — headers, cookies, request bodies, response bodies, timing. Agent
+mode captures the same detail autonomously (see below); the Playwright MCP and
+`agent-browser` providers also produce a HAR, while Chrome DevTools MCP reads
+network traffic directly through its MCP tools.
 
 ### Autonomous agent loop
 

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install Reverse API Engineer with uv or pip, then set up Playwright browsers.
+description: Install Reverse API Engineer with uv or pip; add the [manual] extra for manual-mode capture.
 ---
 
 <Callout type="info" title="What you'll need">
@@ -28,13 +28,27 @@ description: Install Reverse API Engineer with uv or pip, then set up Playwright
   </Tab>
 </Tabs>
 
-## Install Playwright browsers
+## Manual mode: install the browser stack
 
-This downloads the Chromium build that powers manual and agent capture:
+Agent mode (the default) drives capture through browser MCP servers over `npx`
+and needs no extra Python packages. **Manual mode** drives a local Playwright
+browser, which ships in the optional `[manual]` extra. Install the extra, then
+download the Chromium build:
 
-```bash
-playwright install chromium
-```
+<Tabs items={['uv (recommended)', 'pip']}>
+  <Tab value="uv (recommended)">
+    ```bash
+    uv tool install "reverse-api-engineer[manual]"
+    playwright install chromium
+    ```
+  </Tab>
+  <Tab value="pip">
+    ```bash
+    pip install "reverse-api-engineer[manual]"
+    playwright install chromium
+    ```
+  </Tab>
+</Tabs>
 
 ## Verify the install
 

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -30,10 +30,11 @@ description: Install Reverse API Engineer with uv or pip; add the [manual] extra
 
 ## Manual mode: install the browser stack
 
-Agent mode (the default) drives capture through browser MCP servers over `npx`
-and needs no extra Python packages. **Manual mode** drives a local Playwright
-browser, which ships in the optional `[manual]` extra. Install the extra, then
-download the Chromium build:
+Agent mode (the default) drives capture through `npx`-launched browser tooling —
+browser MCP servers (Playwright or Chrome DevTools) or the Vercel `agent-browser`
+CLI — and needs no extra Python packages. **Manual mode** drives a local
+Playwright browser, which ships in the optional `[manual]` extra. Install the
+extra, then download the Chromium build:
 
 <Tabs items={['uv (recommended)', 'pip']}>
   <Tab value="uv (recommended)">

--- a/website/content/docs/modes/manual.mdx
+++ b/website/content/docs/modes/manual.mdx
@@ -11,6 +11,16 @@ Manual mode runs the full pipeline with you in the driver's seat.
   caption="Drive the browser yourself, get a client when you're done."
 />
 
+<Callout type="info" title="Requires the browser extra">
+Manual mode drives a local Playwright browser, which ships in the optional
+`[manual]` extra (agent mode doesn't need it). Install it once:
+
+```bash
+uv tool install "reverse-api-engineer[manual]"   # or: pip install "reverse-api-engineer[manual]"
+playwright install chromium
+```
+</Callout>
+
 ## How it works
 
 <Steps>

--- a/website/content/docs/quick-start.mdx
+++ b/website/content/docs/quick-start.mdx
@@ -23,6 +23,13 @@ description: From a fresh install to a working API client in under five minutes.
   <Step>
     ### Run your first manual capture
 
+    <Callout type="info">
+      Manual mode needs the Playwright browser stack from the optional `[manual]`
+      extra: `uv tool install "reverse-api-engineer[manual]"` (or add `[manual]`
+      to your `pip install`) followed by `playwright install chromium`. Agent
+      mode needs neither.
+    </Callout>
+
     Press **`Shift+Tab`** once to switch from agent mode to manual mode, then
     type a goal: what you want from the site.
 

--- a/website/src/app/llms.txt/route.ts
+++ b/website/src/app/llms.txt/route.ts
@@ -15,7 +15,7 @@ export function GET() {
 
 > ${appTagline}
 
-${appName} is an open-source CLI that captures browser traffic with Playwright (or Chrome DevTools MCP) and uses your configured AI SDK to generate a typed API client from the recorded HAR. Output languages: Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C.
+${appName} is an open-source CLI that captures browser traffic — via browser MCP servers in the default agent mode (or a local Playwright browser with the optional \`[manual]\` extra) — and uses your configured AI SDK to generate a typed API client from the recorded HAR. Output languages: Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C.
 
 ## Documentation
 

--- a/website/src/app/llms.txt/route.ts
+++ b/website/src/app/llms.txt/route.ts
@@ -15,7 +15,7 @@ export function GET() {
 
 > ${appTagline}
 
-${appName} is an open-source CLI that captures browser traffic — via browser MCP servers in the default agent mode (or a local Playwright browser with the optional \`[manual]\` extra) — and uses your configured AI SDK to generate a typed API client from the recorded HAR. Output languages: Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C.
+${appName} is an open-source CLI that captures browser traffic — in the default agent mode via a browser MCP server (Playwright or Chrome DevTools) or the Vercel agent-browser CLI, or in manual mode via a local Playwright browser (optional \`[manual]\` extra) — and uses your configured AI SDK to generate a typed API client from the captured requests. Output languages: Python, JavaScript, TypeScript, Go, Java, C#, PHP, Ruby, and C.
 
 ## Documentation
 


### PR DESCRIPTION
## What

Move `playwright` + `playwright-stealth` out of the base dependencies into a new `[manual]` optional-dependency group, so the base install is lightweight.

## Why

Agent mode — the default — captures traffic via **external MCP servers** (`chrome-devtools-mcp` / `rae-playwright-mcp` launched over `npx`, incl. Chrome auto-connect). It never imports the Python Playwright package. The only code that does is `browser.py`'s `ManualBrowser`, used exclusively by **manual capture mode**.

Playwright (with its browser tooling) was the heaviest base dependency, so it bloated every install — and any embedded runtime that bundles the package — for the common path that doesn't use it. This is groundwork for embedding a slim `reverse-api` in the macOS app (which does its own capture and never needs manual mode).

## Changes

- `pyproject.toml`: `playwright`/`playwright-stealth` → new `[manual]` extra.
- `cli.py`: import `ManualBrowser` lazily inside `run_manual_capture`; if Playwright isn't installed, raise a clear `pip install 'reverse-api-engineer[manual]'` hint instead of a top-level `ImportError`.

## User-visible impact

- **Agent mode / `engineer` / codegen:** unchanged, and now install Playwright-free.
- **Manual capture mode:** now requires `pip install 'reverse-api-engineer[manual]'`. Running it without the extra prints an actionable install message.

## Verification

- Full suite: **835 passed** with a **base-only** install (no Playwright present) — proves nothing broke *and* that the base no longer pulls Playwright.
- `reverse-api --help` works without Playwright.
- Manual mode without the extra raises the friendly install hint.
- `[manual]` extra restores `ManualBrowser` import.

## Note

I did **not** delete `prompts/chat/system.md` (previously flagged as orphaned): no product code loads it, but `tests/test_prompts.py::test_load_chat_system` does, and it looks like intended scaffolding for the upcoming chat surface. Happy to remove it (plus its test) if you'd prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `playwright` and `playwright-stealth` optional via a new `manual` extra to slim the base install. Manual mode now checks for the extra at startup with a clear Chromium install hint, prevents phantom runs, cleans up Playwright on startup errors to avoid REPL loops, and normalizes bare-host URLs.

- **Migration**
  - Manual capture requires: `pip install 'reverse-api-engineer[manual]'` and `playwright install chromium`.

- **Bug Fixes**
  - Fail fast before recording a run when the `[manual]` extra is missing to avoid phantom history entries.
  - Escape exception text in CLI output so `[manual]` isn’t stripped by Rich markup.
  - Stop Playwright when manual capture fails to start to prevent a leaked event loop that breaks the REPL; prepend https:// to bare-host URLs to avoid navigation errors.

<sup>Written for commit 3b103edae1a1572b62221fed01a51a5a47dc99c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/reverse-api-engineer/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Playwright browser stack optional for manual capture mode. The main changes are:

- Moves `playwright` and `playwright-stealth` into a new `manual` extra.
- Updates `uv.lock` so the base package no longer requires Playwright.
- Lazily imports `ManualBrowser` in manual capture and shows an install hint when the extra is missing.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the manual-mode history issue.

Dependency metadata is consistent, but the new base-only manual-mode failure path can leave stale run history.

src/reverse_api/cli.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested verification, but its local artifact references were not uploaded.
- Manual base smoke test ran and exited with code 0, and a ClickException suggested installing reverse-api-engineer\[manual\].
- The reverse-api-engineer --help output printed the root CLI help and exited successfully.
- The manual extra import smoke test ran and exited with code 0, with Playwright, Playwright stealth, and ManualBrowser importable.

<a href="https://app.greptile.com/trex/runs/15468102/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Moves Playwright packages from base dependencies into the new `manual` optional extra. |
| src/reverse_api/cli.py | Lazily imports `ManualBrowser` for manual capture, but records a run before handling a missing manual extra. |
| uv.lock | Updates lock metadata so Playwright dependencies are only included for the `manual` extra. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/reverse_api/cli.py`, line 1863-1876 ([link](https://github.com/kalil0321/reverse-api-engineer/blob/186c80490251975e5193c9e37b5d5dc98f948369/src/reverse_api/cli.py#L1863-L1876)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Avoid failed history entries**
   `session_manager.add_run()` runs before the lazy `ManualBrowser` import, so a base-only install that enters manual mode records a new `manual` run and then raises the missing-extra `ClickException`. That leaves the failed run as the latest history entry with only a `har_dir`, so follow-up flows that operate on the latest run can target a capture that never happened. Import `ManualBrowser` before creating the session record, or remove the run in the `ImportError` path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/reverse_api/cli.py
   Line: 1863-1876

   Comment:
   **Avoid failed history entries**
   `session_manager.add_run()` runs before the lazy `ManualBrowser` import, so a base-only install that enters manual mode records a new `manual` run and then raises the missing-extra `ClickException`. That leaves the failed run as the latest history entry with only a `har_dir`, so follow-up flows that operate on the latest run can target a capture that never happened. Import `ManualBrowser` before creating the session record, or remove the run in the `ImportError` path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/reverse_api/cli.py:1863-1876
**Avoid failed history entries**
`session_manager.add_run()` runs before the lazy `ManualBrowser` import, so a base-only install that enters manual mode records a new `manual` run and then raises the missing-extra `ClickException`. That leaves the failed run as the latest history entry with only a `har_dir`, so follow-up flows that operate on the latest run can target a capture that never happened. Import `ManualBrowser` before creating the session record, or remove the run in the `ImportError` path.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Make Playwright an optional \[manual\] ext..."](https://github.com/kalil0321/reverse-api-engineer/commit/186c80490251975e5193c9e37b5d5dc98f948369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46424727)</sub>

<!-- /greptile_comment -->

## Docs

Updated to reflect the new install: README, CHANGELOG (Unreleased), CONTRIBUTING, and website docs (`installation`, `quick-start`, `modes/manual`) now document the `[manual]` extra and that agent mode needs no Playwright.
