### PR TITLE
Sync main with v0.13.1 and refresh the MCP lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-30
+
+### Fixed
+- **`ModuleNotFoundError: No module named 'httpx'` on a fresh install**: `httpx` was imported at module top level in five modules but never declared as a dependency. It had always arrived transitively through `mcp`, which required `httpx` up to 1.x. `mcp` 2.0 switched to `httpx2` and `claude-agent-sdk` relaxed its pin to `mcp<3`, so new installs stopped resolving `httpx` entirely and every CLI invocation died at import time, `--version` included. Environments created before `mcp` 2.0 kept working, which is why the break only appeared for new users. The package now uses `httpx2` (imported as `httpx`) and declares `httpx2>=2.5.0` explicitly, matching what `mcp` 2.x already pulls in rather than installing a second HTTP client alongside it. ([#122](https://github.com/kalil0321/reverse-api-engineer/issues/122))
+
 ## [0.13.0] - 2026-07-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reverse-api-engineer"
-version = "0.13.0"
+version = "0.13.1"
 description = "The agent that turns websites into APIs."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -54,6 +54,7 @@ dependencies = [
     "aiohttp>=3.13.4",
     "pygments>=2.20.0",
     "cryptography>=46.0.7",
+    "httpx2>=2.5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/reverse_api/auto_engineer.py
+++ b/src/reverse_api/auto_engineer.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from typing import Any
 
-import httpx
+import httpx2 as httpx
 from claude_agent_sdk import (
     ClaudeAgentOptions,
     ClaudeSDKClient,

--- a/src/reverse_api/cli.py
+++ b/src/reverse_api/cli.py
@@ -122,7 +122,7 @@ def default_model_for_configured_sdk(sdk: str | None = None) -> str:
 
 async def _load_opencode_catalog_for_settings() -> dict:
     """Start or reuse OpenCode and load its live provider/model catalog."""
-    import httpx
+    import httpx2 as httpx
 
     from .opencode_runtime import (
         ensure_opencode_server,

--- a/src/reverse_api/ollama_runtime.py
+++ b/src/reverse_api/ollama_runtime.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-import httpx
+import httpx2 as httpx
 
 from .utils import get_config_path
 

--- a/src/reverse_api/opencode_engineer.py
+++ b/src/reverse_api/opencode_engineer.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import httpx
+import httpx2 as httpx
 
 from .base_engineer import BaseEngineer
 from .config import DEFAULT_OPENCODE_MODEL, DEFAULT_OPENCODE_PROVIDER

--- a/src/reverse_api/opencode_runtime.py
+++ b/src/reverse_api/opencode_runtime.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-import httpx
+import httpx2 as httpx
 
 from .utils import get_config_path
 

--- a/src/reverse_api/utils.py
+++ b/src/reverse_api/utils.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
-import httpx
+import httpx2 as httpx
 
 from . import __version__
 

--- a/tests/test_auto_engineer.py
+++ b/tests/test_auto_engineer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 from claude_agent_sdk import (
     AssistantMessage,

--- a/tests/test_cli_settings.py
+++ b/tests/test_cli_settings.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 
 from reverse_api import cli
 

--- a/tests/test_ollama_runtime.py
+++ b/tests/test_ollama_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from reverse_api import ollama_runtime

--- a/tests/test_opencode_engineer.py
+++ b/tests/test_opencode_engineer.py
@@ -5,7 +5,7 @@ import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from reverse_api.opencode_engineer import (

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from reverse_api import opencode_runtime

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -525,7 +525,7 @@ class TestGenerateFolderNameOpencodeAsync:
 
         with patch("reverse_api.config.ConfigManager"):
             with patch("reverse_api.utils.get_config_path"):
-                with patch("httpx.AsyncClient") as mock_async:
+                with patch("httpx2.AsyncClient") as mock_async:
                     mock_async.return_value.__aenter__ = AsyncMock(return_value=mock_client)
                     mock_async.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -593,7 +593,7 @@ class TestGenerateFolderNameOpencodeAsync:
                 "opencode_model": "claude-opus-4-6",
             }.get(key, default)
             with patch("reverse_api.utils.get_config_path"):
-                with patch("httpx.AsyncClient") as mock_async:
+                with patch("httpx2.AsyncClient") as mock_async:
                     mock_async.return_value.__aenter__ = AsyncMock(return_value=mock_client)
                     mock_async.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -651,7 +651,7 @@ class TestGenerateFolderNameOpencodeAsync:
                 "opencode_model": "claude-opus-4-6",
             }.get(key, default)
             with patch("reverse_api.utils.get_config_path"):
-                with patch("httpx.AsyncClient") as mock_async:
+                with patch("httpx2.AsyncClient") as mock_async:
                     mock_async.return_value.__aenter__ = AsyncMock(return_value=mock_client)
                     mock_async.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -703,7 +703,7 @@ class TestGenerateFolderNameOpencodeAsync:
                 "opencode_model": "claude-opus-4-6",
             }.get(key, default)
             with patch("reverse_api.utils.get_config_path"):
-                with patch("httpx.AsyncClient") as mock_async:
+                with patch("httpx2.AsyncClient") as mock_async:
                     mock_async.return_value.__aenter__ = AsyncMock(return_value=mock_client)
                     mock_async.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -759,7 +759,7 @@ class TestGenerateFolderNameOpencodeAsync:
                 "opencode_model": "claude-opus-4-6",
             }.get(key, default)
             with patch("reverse_api.utils.get_config_path"):
-                with patch("httpx.AsyncClient") as mock_async:
+                with patch("httpx2.AsyncClient") as mock_async:
                     mock_async.return_value.__aenter__ = AsyncMock(return_value=mock_client)
                     mock_async.return_value.__aexit__ = AsyncMock(return_value=False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' or sys_platform != 'emscripten'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -719,6 +723,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -743,12 +760,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.16"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1558,13 +1601,14 @@ wheels = [
 
 [[package]]
 name = "reverse-api-engineer"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "claude-agent-sdk" },
     { name = "click" },
     { name = "cryptography" },
+    { name = "httpx2" },
     { name = "pygments" },
     { name = "questionary" },
     { name = "requests" },
@@ -1603,6 +1647,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = ">=0.1.0" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "markdownify", marker = "extra == 'collector'", specifier = ">=0.12.0" },
     { name = "playwright", marker = "extra == 'manual'", specifier = ">=1.40.0" },
     { name = "playwright-stealth", marker = "extra == 'manual'", specifier = ">=1.0.0" },
@@ -1940,6 +1985,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1974,8 +2028,8 @@ name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [


### PR DESCRIPTION
`main` still declares 0.13.0, while PyPI and the latest GitHub release are at 0.13.1. Bring the existing release fix onto the default branch, preserving the website and Cursor Bridge fixes already on `main` (#115 and #116).

The release fixes CLI startup after a fresh install by declaring and using `httpx2`. Refresh the committed Claude Agent SDK/MCP lock as well: it now resolves `claude-agent-sdk 0.2.157` and `mcp 2.2.0`, removing `httpx`, `httpx-sse`, and `httpcore`. Clarify the changelog's distinction between MCP 1.x and 2.x environments. New subprocess tests check `--version`, `--help`, and HTTP-client module imports while explicitly blocking legacy HTTP clients.

Validation on the merged tree:
- 868 tests passed with the frozen dependency lock; confirmed that `httpx`, `httpx-sse`, and `httpcore` are absent. A temporary pytest fixture redirected Cursor test messages to temporary storage; macOS file-watcher tests ran outside the filesystem sandbox. Five existing coroutine warnings remain.
- The new startup tests reproduced the failure with the original MCP 1.x lock and passed with the updated lock. Ruff checks and `uv lock --check --offline` passed.
- The isolated child explicitly loads the same package location as pytest. Both CLI smoke tests pass with an editable install and with an uninstalled `PYTHONPATH=src` checkout. Injecting a legacy `httpx` import into a separate parent checkout still triggers the expected failures, even with a clean editable install present.
- The release fix was also validated by building and installing a wheel in a fresh base environment: `--version`, `--help`, and imports of all HTTP-client modules succeeded without `httpx` or Playwright.

The published `v0.13.1` tag and PyPI artifacts are unchanged; this does not publish a new package.
